### PR TITLE
fix: change plugin name verification to otp

### DIFF
--- a/packages/plugin-auth-sms/src/server/plugin.ts
+++ b/packages/plugin-auth-sms/src/server/plugin.ts
@@ -17,7 +17,7 @@ export class SmsAuthPlugin extends Plugin {
       },
     });
 
-    const verificationPlugin: VerificationPlugin = this.app.getPlugin('verification');
+    const verificationPlugin: VerificationPlugin = this.app.getPlugin('otp');
     if (!verificationPlugin) {
       this.app.logger.warn('sms-auth: @tachybase/plugin-otp is required');
       return;

--- a/packages/plugin-auth-sms/src/server/sms-auth.ts
+++ b/packages/plugin-auth-sms/src/server/sms-auth.ts
@@ -16,7 +16,7 @@ export class SMSAuth extends BaseAuth {
 
   async validate() {
     const ctx = this.ctx;
-    const verificationPlugin: VerificationPlugin = ctx.app.getPlugin('verification');
+    const verificationPlugin: VerificationPlugin = ctx.app.getPlugin('otp');
     if (!verificationPlugin) {
       throw new Error('sms-auth: @tachybase/plugin-otp is required');
     }

--- a/packages/plugin-otp/src/server/actions/verifications.ts
+++ b/packages/plugin-otp/src/server/actions/verifications.ts
@@ -11,7 +11,7 @@ import { CODE_STATUS_UNUSED } from '../constants';
 const asyncRandomInt = promisify(randomInt);
 
 export async function create(context: Context, next: Next) {
-  const plugin = context.app.getPlugin('verification') as Plugin;
+  const plugin = context.app.getPlugin('otp') as Plugin;
 
   const { values } = context.action.params;
   const interceptor = plugin.interceptors.get(values?.type);
@@ -21,7 +21,7 @@ export async function create(context: Context, next: Next) {
 
   const providerItem = await plugin.getDefault();
   if (!providerItem) {
-    console.error(`[verification] no provider for action (${values.type}) provided`);
+    console.error(`[otp] no provider for action (${values.type}) provided`);
     return context.throw(500);
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated plugin references from 'verification' to 'otp' across authentication and verification functionalities.
  
- **Bug Fixes**
	- Improved error messages to reflect the requirement for the `@tachybase/plugin-otp`.

- **Documentation**
	- Enhanced logging to clarify plugin context in error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->