### PR TITLE
fix: db event afterUpdate trigger four times

### DIFF
--- a/packages/database/src/update-associations.ts
+++ b/packages/database/src/update-associations.ts
@@ -35,7 +35,7 @@ export function belongsToManyAssociations(instance: Model): Array<BelongsToMany>
   return Object.entries(associations)
     .filter((entry) => {
       const [key, association] = entry;
-      return association.associationType == 'BelongsToMany';
+      return association.associationType === 'BelongsToMany';
     })
     .map((association) => {
       return <BelongsToMany>association[1];
@@ -184,7 +184,7 @@ function isReverseAssociationPair(a: any, b: any) {
   typeSet.add(a.associationType);
   typeSet.add(b.associationType);
 
-  if (typeSet.size == 1 && typeSet.has('BelongsToMany')) {
+  if (typeSet.size === 1 && typeSet.has('BelongsToMany')) {
     return (
       a.through.tableName === b.through.tableName &&
       a.target.name === b.source.name &&
@@ -197,8 +197,8 @@ function isReverseAssociationPair(a: any, b: any) {
   }
 
   if ((typeSet.has('HasOne') && typeSet.has('BelongsTo')) || (typeSet.has('HasMany') && typeSet.has('BelongsTo'))) {
-    const sourceAssoc = a.associationType == 'BelongsTo' ? b : a;
-    const targetAssoc = sourceAssoc == a ? b : a;
+    const sourceAssoc = a.associationType === 'BelongsTo' ? b : a;
+    const targetAssoc = sourceAssoc === a ? b : a;
 
     return (
       sourceAssoc.source.name === targetAssoc.target.name &&
@@ -284,7 +284,10 @@ export async function updateSingleAssociation(
   };
 
   if (isUndefinedOrNull(value)) {
-    return await removeAssociation();
+    if (!isUndefinedOrNull(await model[association.accessors.get]())) {
+      return await removeAssociation();
+    }
+    return true;
   }
 
   // @ts-ignore
@@ -335,7 +338,7 @@ export async function updateSingleAssociation(
     });
 
     if (instance) {
-      await model[setAccessor](instance, { context, transaction });
+      await model[setAccessor](instance, { context, transaction, hooks: false });
 
       if (!recursive) {
         return;

--- a/packages/plugin-audit-logs/src/client/collections.tsx
+++ b/packages/plugin-audit-logs/src/client/collections.tsx
@@ -1,3 +1,5 @@
+import { AssociationField } from '@tachybase/client';
+
 import { tval } from './locale';
 
 export const useAuditLogsCollection = () => {
@@ -63,6 +65,16 @@ export const useAuditLogsCollection = () => {
           'x-component': 'AssociationField',
           'x-component-props': { fieldNames: { value: 'name', label: 'title' }, ellipsis: true },
           'x-read-pretty': true,
+        },
+      },
+      {
+        name: 'collectionName',
+        type: 'string',
+        interface: 'string',
+        uiSchema: {
+          type: 'string',
+          title: tval('Collection name'),
+          'x-component': 'Input',
         },
       },
       {

--- a/packages/plugin-audit-logs/src/server/index.ts
+++ b/packages/plugin-audit-logs/src/server/index.ts
@@ -45,8 +45,8 @@ export default class PluginActionLogs extends Plugin {
     });
   }
 
-  async handleSyncMessage(message: any): Promise<void> {
-    if (message.type === 'auditLog') {
+  async handleSyncMessage(message: Readonly<any>): Promise<void> {
+    if (message?.type === 'auditLog') {
       const { values } = message;
       if (!isMainThread || !this.app.worker?.available) {
         this.workerCreateAuditLog(values);

--- a/packages/server/src/plugin.ts
+++ b/packages/server/src/plugin.ts
@@ -141,7 +141,7 @@ export abstract class Plugin implements PluginInterface {
 
   async afterRemove() {}
 
-  async handleSyncMessage(message: any) {}
+  async handleSyncMessage(message: Readonly<any>) {}
   async sendSyncMessage(message: any, options?: PubSubManagerPublishOptions & Transactionable) {
     if (!this.name) {
       throw new Error(`plugin name invalid`);

--- a/packages/server/src/pub-sub-manager/handler-manager.ts
+++ b/packages/server/src/pub-sub-manager/handler-manager.ts
@@ -12,6 +12,8 @@ export class HandlerManager {
     this.reset();
   }
 
+  public adapterType: string;
+
   protected async getMessageHash(message) {
     const encoder = new TextEncoder();
     const data = encoder.encode(JSON.stringify(message));
@@ -37,7 +39,17 @@ export class HandlerManager {
     return func;
   }
 
-  async handleMessage({ channel, message, callback, debounce }) {
+  async handleMessage({
+    channel,
+    message,
+    callback,
+    debounce,
+  }: {
+    channel: string;
+    message: Readonly<any>;
+    callback: any;
+    debounce: number;
+  }) {
     if (!debounce) {
       await callback(message);
       return;
@@ -61,7 +73,13 @@ export class HandlerManager {
   wrapper(channel, callback, options) {
     const { debounce = 0 } = options;
     return async (wrappedMessage) => {
-      const json = JSON.parse(wrappedMessage);
+      // 内存消息队列不再使用JSON.parse
+      let json;
+      if (this.adapterType !== 'MemoryPubSubAdapter') {
+        json = JSON.parse(wrappedMessage);
+      } else {
+        json = wrappedMessage;
+      }
       if (!this.verifyMessage(json)) {
         return;
       }

--- a/packages/server/src/pub-sub-manager/pub-sub-manager.ts
+++ b/packages/server/src/pub-sub-manager/pub-sub-manager.ts
@@ -39,6 +39,7 @@ export class PubSubManager {
 
   setAdapter(adapter: IPubSubAdapter) {
     this.adapter = adapter;
+    this.handlerManager.adapterType = adapter.constructor.name;
   }
 
   async isConnected() {
@@ -92,11 +93,14 @@ export class PubSubManager {
       return;
     }
 
-    const wrappedMessage = JSON.stringify({
+    const messageRow = {
       publisherId: this.publisherId,
       ...options,
       message: message,
-    });
+    };
+
+    const wrappedMessage =
+      this.adapter.constructor.name === 'MemoryPubSubAdapter' ? messageRow : JSON.stringify(messageRow);
 
     return this.adapter.publish(`${this.channelPrefix}${channel}`, wrappedMessage);
   }

--- a/packages/server/src/pub-sub-manager/types.ts
+++ b/packages/server/src/pub-sub-manager/types.ts
@@ -19,5 +19,5 @@ export interface IPubSubAdapter {
   close(): Promise<any>;
   subscribe(channel: string, callback: PubSubCallback): Promise<any>;
   unsubscribe(channel: string, callback: PubSubCallback): Promise<any>;
-  publish(channel: string, message: string): Promise<any>;
+  publish(channel: string, message: string | object): Promise<any>;
 }


### PR DESCRIPTION
部分表(比如工单系统的newTasks表)会触发4次afterUpdate
优化审计日志,加原始数据集名字,因为有些内置表比如messages会不显示

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added a "Collection name" field to the audit logs collection interface
- **Improvements**
  - Enhanced type checking in database association update logic
  - Improved strict comparison operators in database-related functions
  - Updated message handling logic in the PubSubManager for better adapter type management
  - Expanded publish method to accept both string and object types for messages
<!-- end of auto-generated comment: release notes by coderabbit.ai -->