### PR TITLE
fix: allowNewMenu sometimes not work

### DIFF
--- a/packages/module-backup/src/server/dumper.ts
+++ b/packages/module-backup/src/server/dumper.ts
@@ -254,7 +254,6 @@ export class Dumper extends AppMigrator {
       } finally {
         this.cleanLockFile(backupFileName);
       }
-      // 工作线程无法通知备份完成
     }
 
     return backupFileName;

--- a/packages/module-ui-schema/src/server/repository.ts
+++ b/packages/module-ui-schema/src/server/repository.ts
@@ -215,7 +215,7 @@ export class UiSchemaRepository extends Repository {
     };
 
     const buildTree = (rootNode) => {
-      const children = nodes.filter((node) => node.parent == rootNode['x-uid']);
+      const children = nodes.filter((node) => node.parent === rootNode['x-uid']);
 
       if (children.length > 0) {
         const childrenGroupByType = lodash.groupBy(children, 'type');
@@ -226,8 +226,8 @@ export class UiSchemaRepository extends Repository {
             .sort((a, b) => a['x-index'] - b['x-index']) as any;
 
           rootNode[childType] =
-            childType == 'items'
-              ? properties.length == 1
+            childType === 'items'
+              ? properties.length === 1
                 ? properties[0]
                 : properties
               : properties.reduce((carry, item) => {
@@ -241,7 +241,7 @@ export class UiSchemaRepository extends Repository {
       return nodeAttributeSanitize(rootNode);
     };
 
-    return buildTree(nodes.find((node) => node['x-uid'] == rootUid));
+    return buildTree(nodes.find((node) => node['x-uid'] === rootUid));
   }
 
   @transaction()
@@ -286,7 +286,7 @@ export class UiSchemaRepository extends Repository {
     const oldTree = await this.getJsonSchema(rootUid, { transaction });
     const traverSchemaTree = async (schema, path = []) => {
       const node = schema;
-      const oldNode = path.length == 0 ? oldTree : lodash.get(oldTree, path);
+      const oldNode = path.length === 0 ? oldTree : lodash.get(oldTree, path);
       const oldNodeUid = oldNode['x-uid'];
 
       await this.updateNode(oldNodeUid, node, transaction);
@@ -411,6 +411,8 @@ export class UiSchemaRepository extends Repository {
       const wrapSchemaNodes = await this.insertNewSchema(options.wrap, {
         transaction,
         returnNode: true,
+        target,
+        position,
       });
 
       const lastWrapNode = wrapSchemaNodes[wrapSchemaNodes.length - 1];
@@ -430,6 +432,8 @@ export class UiSchemaRepository extends Repository {
         const insertedSchema = await this.insertNewSchema(schema, {
           transaction,
           returnNode: true,
+          position,
+          target,
         });
 
         schema = insertedSchema[0]['x-uid'];
@@ -468,6 +472,8 @@ export class UiSchemaRepository extends Repository {
     schema: any,
     options?: Transactionable & {
       returnNode?: boolean;
+      position?: string;
+      target?: string;
     },
   ) {
     const { transaction } = options;
@@ -721,7 +727,7 @@ export class UiSchemaRepository extends Repository {
 
         sort = targetSort[0].sort;
 
-        if (targetPosition.type == 'after') {
+        if (targetPosition.type === 'after') {
           sort += 1;
         }
 
@@ -882,7 +888,7 @@ WHERE TreeTable.depth = 1 AND  TreeTable.ancestor = :ancestor and TreeTable.sort
 
     const parentChildrenCount = await this.childrenCount(parent, transaction);
 
-    if (parentChildrenCount == 1) {
+    if (parentChildrenCount === 1) {
       const schema = await db.getRepository('uiSchemas').findOne({
         filter: {
           'x-uid': parent,
@@ -1022,7 +1028,7 @@ WHERE TreeTable.depth = 1 AND  TreeTable.ancestor = :ancestor and TreeTable.sort
       transaction,
     });
 
-    if (nodes[0].length == 0) {
+    if (nodes[0].length === 0) {
       return {};
     }
 
@@ -1055,7 +1061,7 @@ WHERE TreeTable.depth = 1 AND  TreeTable.ancestor = :ancestor and TreeTable.sort
       transaction: options?.transaction,
     });
 
-    if (nodes[0].length == 0) {
+    if (nodes[0].length === 0) {
       return {};
     }
 

--- a/packages/module-ui-schema/src/server/server-hooks/hooks/bind-menu-to-role.ts
+++ b/packages/module-ui-schema/src/server/server-hooks/hooks/bind-menu-to-role.ts
@@ -18,7 +18,7 @@ export async function bindMenuToRole({ schemaInstance, db, options }) {
     const ancestorsIds = ancestors.map((item) => item.get('ancestor'));
     ancestorsIds.push(xUid);
     await db.getRepository('roles.menuUiSchemas', role.get('name')).add({
-      tk: ancestorsIds,
+      tk: [...new Set(ancestorsIds)],
       transaction,
     });
   }

--- a/packages/module-ui-schema/src/server/server-hooks/hooks/bind-menu-to-role.ts
+++ b/packages/module-ui-schema/src/server/server-hooks/hooks/bind-menu-to-role.ts
@@ -6,9 +6,19 @@ export async function bindMenuToRole({ schemaInstance, db, options }) {
     },
   });
 
+  const xUid = schemaInstance.get('x-uid');
   for (const role of addNewMenuRoles) {
+    // 此处由于可能开启allowNewMenu之前父节点没给到角色,导致角色没有权限,所以这里需要给角色添加所有父节点权限
+    const ancestors = await db.getRepository('uiSchemaTreePath').find({
+      fields: ['ancestor'],
+      filter: {
+        descendant: schemaInstance.get('x-uid'),
+      },
+    });
+    const ancestorsIds = ancestors.map((item) => item.get('ancestor'));
+    ancestorsIds.push(xUid);
     await db.getRepository('roles.menuUiSchemas', role.get('name')).add({
-      tk: schemaInstance.get('x-uid'),
+      tk: ancestorsIds,
       transaction,
     });
   }

--- a/packages/module-user/src/server/server.ts
+++ b/packages/module-user/src/server/server.ts
@@ -128,7 +128,7 @@ export default class PluginUsersServer extends Plugin {
         plugin: this,
       },
     });
-    if (isMainThread) {
+    if (!isMainThread) {
       return;
     }
 

--- a/packages/plugin-audit-logs/src/server/index.ts
+++ b/packages/plugin-audit-logs/src/server/index.ts
@@ -6,22 +6,19 @@ import { afterCreate, afterDestroy, afterUpdate } from './hooks';
 
 export default class PluginActionLogs extends Plugin {
   async afterAdd() {
-    if (isMainThread) {
-      return;
+    if (!isMainThread) {
+      // 给工作线程也加监听钩子
+      this.addAuditListener();
     }
-    // 给工作线程也加监听钩子
-    this.db.on('afterCreate', (model, options) => {
-      afterCreate(model, options, this);
-    });
-    this.db.on('afterUpdate', (model, options) => {
-      afterUpdate(model, options, this);
-    });
-    this.db.on('afterDestroy', (model, options) => {
-      afterDestroy(model, options, this);
-    });
   }
 
   async beforeLoad() {
+    if (isMainThread) {
+      this.addAuditListener();
+    }
+  }
+
+  async addAuditListener() {
     this.db.on('afterCreate', (model, options) => {
       afterCreate(model, options, this);
     });


### PR DESCRIPTION
由于可能开启allowNewMenu之前父节点没给到角色,导致角色没有父节点权限,从而看不了子节点
所以这里需要在钩子处给角色添加所有父节点权限

顺便把一个bug修改一下module-user 的users,roles的api事件钩子主线程应该触发

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced menu role assignment logic for improved permission handling across ancestor nodes.
	- Introduced audit listener management for both main and worker threads to improve logging capabilities.
  
- **Bug Fixes**
	- Updated equality checks for consistency and correctness throughout the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->