### PR TITLE
fix: app event afterStart trigger many times

### DIFF
--- a/packages/server/src/plugin-manager/plugin-manager.ts
+++ b/packages/server/src/plugin-manager/plugin-manager.ts
@@ -391,7 +391,7 @@ export class PluginManager {
     // FIXME
     Container.reset();
     Container.set({ id: 'db', value: this.app.db });
-    Container.set({ id: 'app', value: this.app });
+    Container.set({ id: 'app', value: createAppProxy(this.app) });
     Container.set({ id: 'logger', value: this.app.logger });
     await Container.get(WebControllerService).load();
     this.app.setMaintainingMessage('loading plugins...');


### PR DESCRIPTION
afterStart会触发四次甚至多次的问题
plugin里面的app不是真实的app,而是createAppProxy之后的app,这个createAppProxy会标记重启过程中清理事件

Inject的app是真实的app,所以不会清理, set app的时候需要createAppProxy代理一下

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated application instance storage mechanism in the plugin manager to use a proxy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->