### PR TITLE
fix: redisClient.connect() many times

### DIFF
--- a/packages/plugin-prototype-online-user/src/server/services/connection-manager.ts
+++ b/packages/plugin-prototype-online-user/src/server/services/connection-manager.ts
@@ -9,17 +9,21 @@ const KEY_ONLINE_USERS = 'online_users';
 
 @Service()
 export class ConnectionManager {
-  private redisClient = createClient({
+  private static redisClient = createClient({
     url: process.env.REDIS_URL ?? 'redis://127.0.0.1:6379',
   });
-  private redisPubClient = this.redisClient.duplicate();
-  private redisSubClient = this.redisClient.duplicate();
+  private static redisPubClient = this.redisClient.duplicate();
+  private static redisSubClient = this.redisClient.duplicate();
 
   @App()
   private app: Application;
 
   async unload() {
-    for (const client of [this.redisClient, this.redisPubClient, this.redisSubClient]) {
+    for (const client of [
+      ConnectionManager.redisClient,
+      ConnectionManager.redisPubClient,
+      ConnectionManager.redisSubClient,
+    ]) {
       if (client.isOpen) {
         await client.disconnect();
       }
@@ -27,40 +31,36 @@ export class ConnectionManager {
   }
 
   async load() {
-    this.app.on('afterStart', async () => {
-      if (this.redisClient.isOpen) {
-        return;
-      }
-      for (const client of [this.redisClient, this.redisPubClient, this.redisSubClient]) {
-        if (!client.isOpen) {
-          await client.connect();
-        }
-      }
-      if (isMain()) {
-        const keysToDelete: any = await this.redisClient.KEYS(`${KEY_ONLINE_USERS}*`);
-        if (keysToDelete.length > 0) {
-          await this.redisClient.DEL(...keysToDelete);
-        }
-      }
-      await this.loadWsServer();
-    });
-    this.app.on('beforeStop', async () => {
+    this.app.on('afterStop', async () => {
       await this.unload();
     });
+    if (ConnectionManager.redisClient.isOpen) {
+      return;
+    }
+    await ConnectionManager.redisClient.connect();
+    await ConnectionManager.redisPubClient.connect();
+    await ConnectionManager.redisSubClient.connect();
+    if (isMain()) {
+      const keysToDelete: any = await ConnectionManager.redisClient.KEYS(`${KEY_ONLINE_USERS}*`);
+      if (keysToDelete.length > 0) {
+        await ConnectionManager.redisClient.DEL(...keysToDelete);
+      }
+    }
+    await this.loadWsServer();
   }
 
   async loadWsServer() {
     const appName = this.app.name;
     const gateway = Gateway.getInstance();
     const ws = gateway['wsServer'];
-    await this.redisSubClient.SUBSCRIBE(KEY_ONLINE_USERS + appName, async (num) => {
+    await ConnectionManager.redisSubClient.SUBSCRIBE(KEY_ONLINE_USERS + appName, async (num) => {
       if (num !== currentProcessNum()) {
         await notifyAllClients(false);
       }
     });
     const notifyAllClients = async (broadcast = true) => {
       // 有效在线用户
-      const users = (await this.redisClient.HVALS(KEY_ONLINE_USERS + appName)).map((u) => JSON.parse(u));
+      const users = (await ConnectionManager.redisClient.HVALS(KEY_ONLINE_USERS + appName)).map((u) => JSON.parse(u));
       ws.sendToConnectionsByTag('app', appName, {
         type: 'plugin-online-user',
         payload: {
@@ -68,7 +68,7 @@ export class ConnectionManager {
         },
       });
       if (broadcast) {
-        await this.redisPubClient.PUBLISH(KEY_ONLINE_USERS + appName, currentProcessNum());
+        await ConnectionManager.redisPubClient.PUBLISH(KEY_ONLINE_USERS + appName, currentProcessNum());
       }
     };
 
@@ -85,7 +85,7 @@ export class ConnectionManager {
         await notifyAllClients();
       });
       ws.on('close', async () => {
-        await this.redisClient.HDEL(KEY_ONLINE_USERS + appName, ws.id);
+        await ConnectionManager.redisClient.HDEL(KEY_ONLINE_USERS + appName, ws.id);
         await notifyAllClients();
       });
 
@@ -98,7 +98,7 @@ export class ConnectionManager {
               const analysis = jwt.verify(userMeg.payload.token, process.env.APP_KEY) as any;
               const userId = analysis.userId;
               const user = await getUserById(userId);
-              await this.redisClient.HSET(KEY_ONLINE_USERS + appName, ws.id, JSON.stringify(user));
+              await ConnectionManager.redisClient.HSET(KEY_ONLINE_USERS + appName, ws.id, JSON.stringify(user));
               await notifyAllClients();
             } catch (error) {
               console.warn(error.message);

--- a/packages/plugin-prototype-online-user/src/types/index.d.ts
+++ b/packages/plugin-prototype-online-user/src/types/index.d.ts
@@ -1,0 +1,13 @@
+import { RedisClient } from 'redis';
+
+import { WorkerManager } from '../server/workerManager';
+
+declare module '@tachybase/server' {
+  interface Application {
+    online?: {
+      all: RedisClient;
+      pub: RedisClient;
+      sub: RedisClient;
+    };
+  }
+}


### PR DESCRIPTION
备份的时候会执行一次load 一次reload 一次upgrade中的stop
所以两次load会有两次redis client

现在的代码有bug,每次手动网页重启都会建新连接,而不关闭联机

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Enhanced connection management for Redis clients by encapsulating them within the application structure.
  - Updated event-driven connection and disconnection logic for better efficiency.
  - Optimized connection handling to ensure connections are established only when necessary.
  - Streamlined access to Redis clients through a structured online context for improved organization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->