### PR TITLE
fix: clear ui schema cache

### DIFF
--- a/packages/module-web/src/server/migrations/20250116160330-update-uiSchemas.ts
+++ b/packages/module-web/src/server/migrations/20250116160330-update-uiSchemas.ts
@@ -2,7 +2,7 @@ import { Migration } from '@tachybase/server';
 
 export default class extends Migration {
   on = 'afterLoad'; // 'beforeLoad' or 'afterLoad'
-  appVersion = '<0.23.36';
+  appVersion = '<0.23.37';
 
   async up() {
     const uiSchemasRepo = this.db.getRepository('uiSchemas');

--- a/packages/module-web/src/server/migrations/20250116160330-update-uiSchemas.ts
+++ b/packages/module-web/src/server/migrations/20250116160330-update-uiSchemas.ts
@@ -2,14 +2,15 @@ import { Migration } from '@tachybase/server';
 
 export default class extends Migration {
   on = 'afterLoad'; // 'beforeLoad' or 'afterLoad'
-  appVersion = '<0.23.35';
+  appVersion = '<0.23.36';
 
   async up() {
     const uiSchemasRepo = this.db.getRepository('uiSchemas');
 
+    const xUid = 'default-admin-menu';
     await uiSchemasRepo.update({
       filter: {
-        'x-uid': 'default-admin-menu',
+        'x-uid': xUid,
       },
       values: {
         schema: {
@@ -26,6 +27,9 @@ export default class extends Migration {
         },
       },
     });
+    // 清理缓存中的数据
+    await this.app.cache.del(`p_${xUid}`);
+    await this.app.cache.del(`s_${xUid}`);
     this.app.logger.info(`collection [uiSchemas] update ${1} rows`);
   }
 }

--- a/packages/server/src/notice/index.ts
+++ b/packages/server/src/notice/index.ts
@@ -31,7 +31,7 @@ export class NoticeManager {
     eventType?: string;
     event?: unknown;
   }) {
-    this.ws.sendToConnectionsByTag('app', this.app.name, {
+    this.ws?.sendToConnectionsByTag('app', this.app.name, {
       type: 'notice',
       payload: msg,
     });


### PR DESCRIPTION
ui schema有缓存
还有个问题ws.send 这里upgrade的时候ws为空

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated application version to `<0.23.36`
	- Improved error handling in notice management system by adding null-safe method invocation
	- Optimized cache management for default admin menu configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->