### PR TITLE
fix: can not signup

### DIFF
--- a/packages/client/src/built-in/assistant/Assistant.provider.tsx
+++ b/packages/client/src/built-in/assistant/Assistant.provider.tsx
@@ -1,18 +1,15 @@
 import { ToolOutlined } from '@ant-design/icons';
 import { FloatButton } from 'antd';
 
-import { ACLRolesCheckProvider } from '../acl';
 import { PinnedPluginList } from '../pinned-list';
 
 export const AssistantProvider = ({ children }) => {
   return (
     <>
       {children}
-      <ACLRolesCheckProvider>
-        <FloatButton.Group trigger="click" type="default" style={{ right: 24, zIndex: 1250 }} icon={<ToolOutlined />}>
-          <PinnedPluginList belongToFilter="hoverbutton" />
-        </FloatButton.Group>
-      </ACLRolesCheckProvider>
+      <FloatButton.Group trigger="click" type="default" style={{ right: 24, zIndex: 1250 }} icon={<ToolOutlined />}>
+        <PinnedPluginList belongToFilter="hoverbutton" />
+      </FloatButton.Group>
     </>
   );
 };


### PR DESCRIPTION
用户退出登录这里会清除本地token
但是重新进入/signin会请求一次导致无法运行,也点不开注册页面
看不太懂前端这里这样改合适不合适

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified component rendering by removing an additional access control provider from the Assistant component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->