### PR TITLE
fix: assistant acl

### DIFF
--- a/packages/client/src/built-in/assistant/Assistant.provider.tsx
+++ b/packages/client/src/built-in/assistant/Assistant.provider.tsx
@@ -1,15 +1,18 @@
 import { ToolOutlined } from '@ant-design/icons';
 import { FloatButton } from 'antd';
 
+import { ACLRolesCheckProvider } from '../acl';
 import { PinnedPluginList } from '../pinned-list';
 
 export const AssistantProvider = ({ children }) => {
   return (
     <>
       {children}
-      <FloatButton.Group trigger="click" type="default" style={{ right: 24, zIndex: 1250 }} icon={<ToolOutlined />}>
-        <PinnedPluginList belongToFilter="hoverbutton" />
-      </FloatButton.Group>
+      <ACLRolesCheckProvider>
+        <FloatButton.Group trigger="click" type="default" style={{ right: 24, zIndex: 1250 }} icon={<ToolOutlined />}>
+          <PinnedPluginList belongToFilter="hoverbutton" />
+        </FloatButton.Group>
+      </ACLRolesCheckProvider>
     </>
   );
 };

--- a/packages/client/src/built-in/assistant/Assistant.provider.tsx
+++ b/packages/client/src/built-in/assistant/Assistant.provider.tsx
@@ -1,10 +1,15 @@
 import { ToolOutlined } from '@ant-design/icons';
 import { FloatButton } from 'antd';
+import { useLocation } from 'react-router-dom';
 
 import { ACLRolesCheckProvider } from '../acl';
 import { PinnedPluginList } from '../pinned-list';
 
 export const AssistantProvider = ({ children }) => {
+  const location = useLocation();
+  if (location.pathname === '/signin' || location.pathname === '/signup') {
+    return <>{children}</>;
+  }
   return (
     <>
       {children}

--- a/packages/client/src/built-in/assistant/Assistant.provider.tsx
+++ b/packages/client/src/built-in/assistant/Assistant.provider.tsx
@@ -1,18 +1,15 @@
 import { ToolOutlined } from '@ant-design/icons';
 import { FloatButton } from 'antd';
 
-import { ACLRolesCheckProvider } from '../acl';
 import { PinnedPluginList } from '../pinned-list';
 
 export const AssistantProvider = ({ children }) => {
   return (
     <>
       {children}
-      <ACLRolesCheckProvider>
-        <FloatButton.Group trigger="click" type="default" style={{ right: 24, zIndex: 1250 }} icon={<ToolOutlined />}>
-          <PinnedPluginList belongToFilter="hoverbutton" />
-        </FloatButton.Group>
-      </ACLRolesCheckProvider>
+      <FloatButton.Group trigger="click" type="default" style={{ right: 24, zIndex: 1250 }} icon={<ToolOutlined />}>
+        <PinnedPluginList belongToFilter="hoverbutton" />
+      </FloatButton.Group>
     </>
   );
 };


### PR DESCRIPTION
小工具可以不在登录或者注册页面显示
之前可能需要ai等功能需要有权限控制

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced route-specific rendering logic for the Assistant component
- **Improvements**
	- Conditionally display or hide certain UI elements based on current route (/signin or /signup)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->