### PR TITLE
fix: cron off not work, event off

### DIFF
--- a/packages/module-cron/src/server/service/StaticScheduleTrigger.ts
+++ b/packages/module-cron/src/server/service/StaticScheduleTrigger.ts
@@ -66,7 +66,9 @@ export class StaticScheduleTrigger {
       if (!changed) {
         return;
       }
-      this.on(cronjob);
+      if (cronjob.get('enabled')) {
+        this.on(cronjob);
+      }
     });
 
     this.db.on(`${DATABASE_CRON_JOBS}.afterDestroy`, async (cronjob) => {

--- a/packages/module-multi-app/src/server/server.ts
+++ b/packages/module-multi-app/src/server/server.ts
@@ -238,22 +238,12 @@ export class PluginMultiAppManager extends Plugin {
       await this.subAppUpgradeHandler(app);
     });
 
-    // 主动告知客户端状态变化
-    AppSupervisor.getInstance().on('appStatusChanged', async ({ appName, status, options }) => {
-      if (appName === 'main') {
-        return;
-      }
-      const app = await AppSupervisor.getInstance().getApp(appName, {
-        withOutBootStrap: true,
-      });
-      const level = ['error', 'not_found'].includes(status) ? 'error' : 'info';
-      this.app.noticeManager.notify(NOTIFY_STATUS_EVENT_KEY, {
-        app: appName,
-        status: status,
-        level,
-        message: options.error?.message,
-      });
+    const notifyStatusChange = this.notifyStatusChange.bind(this);
+    this.app.on('beforeStop', async (app) => {
+      AppSupervisor.getInstance().off('appStatusChanged', notifyStatusChange);
     });
+    // 主动告知客户端状态变化
+    AppSupervisor.getInstance().on('appStatusChanged', notifyStatusChange);
 
     this.app.acl.allow('applications', 'listPinned', 'loggedIn');
     this.app.acl.allow('applications', 'list', 'loggedIn');
@@ -287,5 +277,18 @@ export class PluginMultiAppManager extends Plugin {
     for (const [key, action] of Object.entries(actions)) {
       this.app.resourcer.registerActionHandler(`applications:${key}`, action);
     }
+  }
+
+  notifyStatusChange({ appName, status, options }) {
+    if (appName === 'main') {
+      return;
+    }
+    const level = ['error', 'not_found'].includes(status) ? 'error' : 'info';
+    this.app.noticeManager.notify(NOTIFY_STATUS_EVENT_KEY, {
+      app: appName,
+      status: status,
+      level,
+      message: options.error?.message,
+    });
   }
 }

--- a/packages/server/src/sync-message-manager.ts
+++ b/packages/server/src/sync-message-manager.ts
@@ -18,6 +18,17 @@ export class SyncMessageManager {
       }
       await this.subscribe(plugin.name, plugin.handleSyncMessage, plugin);
     });
+
+    app.on('beforeStop', async () => {
+      const promises = [];
+      for (const [P, plugin] of app.pm.getPlugins()) {
+        if (!plugin.name) {
+          return;
+        }
+        promises.push(this.unsubscribe(plugin.name, plugin.handleSyncMessage));
+      }
+      await Promise.all(promises);
+    });
   }
 
   get debounce() {

--- a/packages/server/src/sync-message-manager.ts
+++ b/packages/server/src/sync-message-manager.ts
@@ -23,7 +23,7 @@ export class SyncMessageManager {
       const promises = [];
       for (const [P, plugin] of app.pm.getPlugins()) {
         if (!plugin.name) {
-          return;
+          continue;
         }
         promises.push(this.unsubscribe(plugin.name, plugin.handleSyncMessage));
       }


### PR DESCRIPTION
定时任务 禁用没有生效
一些event on之后restart的过程没有off,可能会导致内存泄漏

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cron job scheduling to only enable jobs that are explicitly marked as active.
  - Enhanced application status change notification mechanism.
  - Implemented more robust plugin sync message cleanup during application shutdown.

- **Refactor**
  - Centralized application status change notification logic.
  - Improved event handling for plugin management and synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->