### PR TITLE
fix: postgres search column not found

### DIFF
--- a/packages/plugin-full-text-search/src/server/dialects/FieldBase.ts
+++ b/packages/plugin-full-text-search/src/server/dialects/FieldBase.ts
@@ -40,6 +40,10 @@ export class FieldBase {
 
   public number(params: handleFieldParams): WhereOptions<any> {
     const { field, keyword } = params;
+    // keyword不是数字则不作为搜索条件
+    if (isNaN(Number(keyword))) {
+      return null;
+    }
     return {
       [Op.and]: [
         where(

--- a/packages/plugin-full-text-search/src/server/dialects/FieldPostgres.ts
+++ b/packages/plugin-full-text-search/src/server/dialects/FieldPostgres.ts
@@ -1,6 +1,6 @@
 import { fn, Op, where } from '@tachybase/database';
 
-import { col } from 'sequelize';
+import { col, literal, WhereOptions } from 'sequelize';
 
 import { handleFieldParams } from '../types';
 import { escapeLike } from '../utils';
@@ -53,5 +53,23 @@ export class FieldPostgres extends FieldBase {
         [this.like]: `%${escapeLike(keyword)}%`,
       },
     });
+  }
+
+  public number(params: handleFieldParams): WhereOptions<any> {
+    const { field, keyword } = params;
+    // keyword不是数字则不作为搜索条件
+    if (isNaN(Number(keyword))) {
+      return null;
+    }
+    return {
+      [Op.and]: [
+        where(
+          literal(`CAST("${field}" AS TEXT)`), // 确保不加引号，直接插入 SQL 表达式
+          {
+            [Op.like]: `%${escapeLike(keyword)}%`,
+          },
+        ),
+      ],
+    };
   }
 }


### PR DESCRIPTION
全文搜索遇到不存在的列

因为搜索数字的时候pg没注意字段大小写

<img width="1381" alt="image" src="https://github.com/user-attachments/assets/0433ce01-f823-4f39-aeec-384a7d8bcc05" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced numeric search functionality with additional input validation.
	- Now, only valid numeric values are processed for search conditions while non-numeric inputs are gracefully ignored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->