### PR TITLE
fix: sub domain sub app not get websocket message

### DIFF
--- a/packages/client/src/application/WebSocketClient.ts
+++ b/packages/client/src/application/WebSocketClient.ts
@@ -50,7 +50,7 @@ export class WebSocketClient {
       return;
     }
     const subApp = getSubAppName(this.app.getPublicPath());
-    const queryString = subApp ? `?__appName=${subApp}` : '';
+    const queryString = subApp ? `?__appName=${subApp}` : `?__hostname=${window.location.hostname}`;
     const wsPath = this.options.basename || '/ws';
     if (this.options.url) {
       const url = new URL(this.options.url);

--- a/packages/module-multi-app/package.json
+++ b/packages/module-multi-app/package.json
@@ -11,7 +11,9 @@
   "scripts": {
     "build": "tachybase-build --no-dts @tachybase/module-multi-app"
   },
-  "dependencies": {},
+  "dependencies": {
+    "qs": "^6.13.1"
+  },
   "devDependencies": {
     "@ant-design/icons": "^5.5.2",
     "@tachybase/schema": "workspace:*",

--- a/packages/module-multi-app/src/server/middlewares/app-selector.ts
+++ b/packages/module-multi-app/src/server/middlewares/app-selector.ts
@@ -1,8 +1,27 @@
+import qs from 'qs';
+
 export function appSelectorMiddleware(app) {
   return async (ctx, next) => {
     const { req } = ctx;
 
-    if (!ctx.resolvedAppName && req.headers['x-hostname']) {
+    let subAppName;
+    if (!ctx.resolvedAppName) {
+      if (req.headers['x-hostname']) {
+        subAppName = req.headers['x-hostname'];
+      } else {
+        // 类似/ws?__hostname=bbb.localhost
+        const url = req.url;
+        // 获取path和query,通过query.__hostname即为子应用的cname
+        const [path, query] = url.split('?');
+        if (path === '/ws' && query) {
+          const queryObj = qs.parse(query);
+          subAppName = queryObj.__hostname;
+        }
+      }
+
+      if (!subAppName) {
+        return next();
+      }
       const repository = app.db.getRepository('applications');
       if (!repository) {
         await next();
@@ -11,7 +30,7 @@ export function appSelectorMiddleware(app) {
 
       const appInstance = await repository.findOne({
         filter: {
-          cname: req.headers['x-hostname'],
+          cname: subAppName,
         },
       });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1816,6 +1816,9 @@ importers:
       '@tachybase/utils':
         specifier: workspace:*
         version: link:../utils
+      qs:
+        specifier: ^6.13.1
+        version: 6.13.1
     devDependencies:
       '@ant-design/icons':
         specifier: ^5.5.2
@@ -26223,7 +26226,7 @@ snapshots:
 
   es-define-property@1.0.0:
     dependencies:
-      get-intrinsic: 1.2.4
+      get-intrinsic: 1.2.6
 
   es-define-property@1.0.1: {}
 
@@ -26247,7 +26250,7 @@ snapshots:
 
   es-set-tostringtag@2.0.3:
     dependencies:
-      get-intrinsic: 1.2.4
+      get-intrinsic: 1.2.6
       has-tostringtag: 1.0.2
       hasown: 2.0.2
 
@@ -27061,11 +27064,11 @@ snapshots:
   globalthis@1.0.4:
     dependencies:
       define-properties: 1.2.1
-      gopd: 1.0.1
+      gopd: 1.2.0
 
   gopd@1.0.1:
     dependencies:
-      get-intrinsic: 1.2.4
+      get-intrinsic: 1.2.6
 
   gopd@1.2.0: {}
 
@@ -27796,7 +27799,7 @@ snapshots:
   is-weakset@2.0.3:
     dependencies:
       call-bind: 1.0.7
-      get-intrinsic: 1.2.4
+      get-intrinsic: 1.2.6
 
   is-what@3.14.1: {}
 
@@ -31707,7 +31710,7 @@ snapshots:
       define-data-property: 1.1.4
       es-errors: 1.3.0
       function-bind: 1.1.2
-      get-intrinsic: 1.2.4
+      get-intrinsic: 1.2.6
       gopd: 1.0.1
       has-property-descriptors: 1.0.2
 


### PR DESCRIPTION
在a.localhost这样的域名访问下的子应用没法获取到websocket消息
导致启用插件的时候没法立即反馈给前端刷新
<img width="1879" alt="image" src="https://github.com/user-attachments/assets/ac066c68-4da4-4c94-9117-20b828f2d4ec" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved connection handling: URLs now automatically incorporate the current hostname when a specific app parameter is not provided, enhancing connection reliability.
  - Enhanced routing logic: The system now better determines the appropriate application context by considering multiple sources, which improves request handling in multi-application scenarios.
- **Chores**
  - Added a new library to strengthen query string parsing for more robust URL parameter processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->