### PR TITLE
fix: subapp get swagger not set headers hostname

### DIFF
--- a/packages/plugin-devtools/src/client/Document.tsx
+++ b/packages/plugin-devtools/src/client/Document.tsx
@@ -19,6 +19,8 @@ const Documentation = () => {
   const { data: urls } = useRequest<{ data: { name: string; url: string }[] }>({ url: 'swagger:getUrls' });
   const app = useApp();
   const requestInterceptor = (req) => {
+    // 如果是a.localhost访问的子应用,而且主应用未开启api-doc,但是子应用开启
+    req.headers['X-Hostname'] = window.location.hostname;
     if (!req.headers['Authorization']) {
       const appName = getSubAppName(app.getPublicPath());
       if (appName) {


### PR DESCRIPTION
主应用不开启插件api开发工具
子应用开启插件api开发工具
子应用通过指定子域名方式访问api文档,就会出错

api文档 swagger:get这里没设置X-Hostname被认为是main了

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced the handling of API documentation requests in multi-application scenarios. This update ensures that environment-specific details are correctly passed along, improving consistency and reliability when accessing documentation from sub-application environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->