### PR TITLE
fix: http collection acl

### DIFF
--- a/packages/plugin-data-source-common/src/server/plugin.ts
+++ b/packages/plugin-data-source-common/src/server/plugin.ts
@@ -24,7 +24,13 @@ export class PluginExternalDataSourceServer extends Plugin {
     }
   }
 
-  async load() {}
+  async load() {
+    // 通过菜单权限数据源管理的管理员能够运行测试,crud任意操作
+    this.app.acl.registerSnippet({
+      name: 'pm.database-connections.manager',
+      actions: ['dataSources.*:*'],
+    });
+  }
 
   async install() {}
 


### PR DESCRIPTION
http 数据表的Try it out的权限没给到admin
现在允许通过短语设置上给到数据源的用户都能操作
<img width="780" alt="image" src="https://github.com/user-attachments/assets/3cad3de8-df59-4a6b-9f5d-eba8fb948f8e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced permission management for data source operations, allowing authorized users to perform creation, reading, updating, and deletion actions on their data sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->