### PR TITLE
fix: database event send transaction to workflow

### DIFF
--- a/packages/module-event-source/src/server/services/DatabaseEventService.ts
+++ b/packages/module-event-source/src/server/services/DatabaseEventService.ts
@@ -54,7 +54,7 @@ export class DatabaseEventService {
         const result = (await pluginWorkflow.trigger(
           wf,
           { data: webhookCtx.body },
-          { dbModel: model, dbOptions: options },
+          { dbModel: model, dbOptions: options, ...options },
         )) as Processor;
         if (result?.lastSavedJob.status === JOB_STATUS.ERROR) {
           throw new Error(result.lastSavedJob?.result);


### PR DESCRIPTION
数据库时间保持事务的一致性数据库触发源头和数据库操作用同一个事务
经测试,不同数据源这个事务相当于无效事务不影响数据操作

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated internal processing for event handling to streamline data flow. No changes were made to user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->