### PR TITLE
fix: custom workflow trigger show throw error after delete association field

### DIFF
--- a/packages/module-workflow/src/server/features/omni-trigger/CustomActionTrigger.ts
+++ b/packages/module-workflow/src/server/features/omni-trigger/CustomActionTrigger.ts
@@ -32,7 +32,7 @@ export class OmniTrigger extends Trigger {
         ctx.status = err.status;
       },
     );
-    workflow.app.use(this.middleware, { tag: 'workflowTrigger', after: 'dataSource' });
+    workflow.app.resourcer.use(this.middleware, { tag: 'workflowTrigger', after: 'dataSource' });
   }
   triggerAction = async (context, next) => {
     const {


### PR DESCRIPTION
之前workflow config里面配置了一个关联字段
**后续删了这个字段**

<img width="1311" alt="image" src="https://github.com/user-attachments/assets/91d9bd3b-3b9a-437e-bf71-39b6af106e7a" />


但是新建的的这个提交+绑定工作流 依然会执行成功
这里应该报错出来

或许应该在delete 字段的时候做逻辑判断,遍历一遍工作流(提示或者自动删除这个appends)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Revised the backend middleware integration for more modular and reliable request handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->