### PR TITLE
fix: custom request

### DIFF
--- a/packages/client/src/schema-component/antd/action/Action.Designer.tsx
+++ b/packages/client/src/schema-component/antd/action/Action.Designer.tsx
@@ -263,7 +263,7 @@ export function AfterSuccess() {
   const ctx = useActionContext();
   const openMode = findSchema(ctx.fieldSchema);
   const component = fieldSchema.parent.parent['x-component'];
-  const schema = { ...(afterSuccessSchema as any) };
+  const schema = { ...(afterSuccessSchema(t) as any) };
   if (
     ((!openMode || openMode === 'page') && (component as string).includes('Form')) ||
     !(component as string).includes('Form')

--- a/packages/client/src/schema-component/antd/action/utils.ts
+++ b/packages/client/src/schema-component/antd/action/utils.ts
@@ -138,59 +138,61 @@ export const linkageAction = async ({
   }
 };
 
-export const afterSuccessSchema: ISchema = {
-  type: 'object',
-  title: '{{t("After successful submission")}}',
-  properties: {
-    successMessage: {
-      title: '{{t("Popup message")}}',
-      'x-decorator': 'FormItem',
-      'x-component': 'Input.TextArea',
-      'x-component-props': {},
-    },
-    popupClose: {
-      title: '{{t("Popup close method")}}',
-      enum: [
-        { label: '{{t("Automatic close")}}', value: false },
-        { label: '{{t("Manually close")}}', value: true },
-      ],
-      'x-decorator': 'FormItem',
-      'x-component': 'Radio.Group',
-      'x-component-props': {},
-    },
-    manualClose: {
-      title: '{{t("Message clear metchod")}}',
-      enum: [
-        { label: '{{t("Automatic close")}}', value: false },
-        { label: '{{t("Manually close")}}', value: true },
-      ],
-      'x-decorator': 'FormItem',
-      'x-component': 'Radio.Group',
-      'x-component-props': {},
-    },
-    redirecting: {
-      title: '{{t("Then")}}',
-      enum: [
-        { label: '{{t("Stay on current page")}}', value: false },
-        { label: '{{t("Redirect to")}}', value: true },
-      ],
-      'x-decorator': 'FormItem',
-      'x-component': 'Radio.Group',
-      'x-component-props': {},
-      'x-reactions': {
-        target: 'redirectTo',
-        fulfill: {
-          state: {
-            visible: '{{!!$self.value}}',
+export const afterSuccessSchema: (t) => ISchema = (t) => {
+  return {
+    type: 'object',
+    title: t('After successful submission'),
+    properties: {
+      successMessage: {
+        title: '{{t("Popup message")}}',
+        'x-decorator': 'FormItem',
+        'x-component': 'Input.TextArea',
+        'x-component-props': {},
+      },
+      popupClose: {
+        title: '{{t("Popup close method")}}',
+        enum: [
+          { label: '{{t("Automatic close")}}', value: false },
+          { label: '{{t("Manually close")}}', value: true },
+        ],
+        'x-decorator': 'FormItem',
+        'x-component': 'Radio.Group',
+        'x-component-props': {},
+      },
+      manualClose: {
+        title: '{{t("Message clear metchod")}}',
+        enum: [
+          { label: '{{t("Automatic close")}}', value: false },
+          { label: '{{t("Manually close")}}', value: true },
+        ],
+        'x-decorator': 'FormItem',
+        'x-component': 'Radio.Group',
+        'x-component-props': {},
+      },
+      redirecting: {
+        title: '{{t("Then")}}',
+        enum: [
+          { label: '{{t("Stay on current page")}}', value: false },
+          { label: '{{t("Redirect to")}}', value: true },
+        ],
+        'x-decorator': 'FormItem',
+        'x-component': 'Radio.Group',
+        'x-component-props': {},
+        'x-reactions': {
+          target: 'redirectTo',
+          fulfill: {
+            state: {
+              visible: '{{!!$self.value}}',
+            },
           },
         },
       },
+      redirectTo: {
+        title: '{{t("Link")}}',
+        'x-decorator': 'FormItem',
+        'x-component': 'Input',
+        'x-component-props': {},
+      },
     },
-    redirectTo: {
-      title: '{{t("Link")}}',
-      'x-decorator': 'FormItem',
-      'x-component': 'Input',
-      'x-component-props': {},
-    },
-  },
+  };
 };

--- a/packages/plugin-action-custom-request/src/client/components/CustomRequestAfter.tsx
+++ b/packages/plugin-action-custom-request/src/client/components/CustomRequestAfter.tsx
@@ -1,0 +1,134 @@
+import React, { useState } from 'react';
+import {
+  AfterSuccess,
+  findSchema,
+  SchemaSettingsModalItem,
+  useActionContext,
+  useDesignable,
+  useTranslation,
+} from '@tachybase/client';
+import { ISchema, useFieldSchema } from '@tachybase/schema';
+
+import { Checkbox, Form, Input, Space } from 'antd';
+
+import { CustomResponseTemplate } from './CustomResponseTemplate';
+
+const afterSuccessSchema: (t) => ISchema = (t) => {
+  return {
+    type: 'object',
+    title: t('After successful submission'),
+    properties: {
+      down: {
+        title: '{{t("Is DownLoad")}}',
+        'x-decorator': 'FormItem',
+        'x-component': 'Checkbox',
+        'x-component-props': {},
+      },
+      downTitle: {
+        title: '{{t("Is DownLoad")}}',
+        default: 'document.docx',
+        'x-decorator': 'FormItem',
+        'x-component': 'Input',
+        'x-component-props': {},
+        'x-reactions': {
+          dependencies: ['down'],
+          fulfill: {
+            state: {
+              visible: '{{!!$deps[0]}}',
+            },
+          },
+        },
+      },
+      successMessage: {
+        title: '{{t("Popup message")}}',
+        'x-decorator': 'FormItem',
+        'x-component': CustomResponseTemplate,
+        'x-component-props': {},
+        'x-reactions': {
+          dependencies: ['down'],
+          fulfill: {
+            state: {
+              visible: '{{!$deps[0]}}',
+            },
+          },
+        },
+      },
+      popupClose: {
+        title: '{{t("Popup close method")}}',
+        enum: [
+          { label: '{{t("Automatic close")}}', value: false },
+          { label: '{{t("Manually close")}}', value: true },
+        ],
+        'x-decorator': 'FormItem',
+        'x-component': 'Radio.Group',
+        'x-component-props': {},
+      },
+      manualClose: {
+        title: '{{t("Message clear metchod")}}',
+        enum: [
+          { label: '{{t("Automatic close")}}', value: false },
+          { label: '{{t("Manually close")}}', value: true },
+        ],
+        'x-decorator': 'FormItem',
+        'x-component': 'Radio.Group',
+        'x-component-props': {},
+      },
+      redirecting: {
+        title: '{{t("Then")}}',
+        enum: [
+          { label: '{{t("Stay on current page")}}', value: false },
+          { label: '{{t("Redirect to")}}', value: true },
+        ],
+        'x-decorator': 'FormItem',
+        'x-component': 'Radio.Group',
+        'x-component-props': {},
+        'x-reactions': {
+          target: 'redirectTo',
+          fulfill: {
+            state: {
+              visible: '{{!!$self.value}}',
+            },
+          },
+        },
+      },
+      redirectTo: {
+        title: '{{t("Link")}}',
+        'x-decorator': 'FormItem',
+        'x-component': 'Input',
+        'x-component-props': {},
+      },
+    },
+  };
+};
+
+export function CustomRequestAfter() {
+  const { dn } = useDesignable();
+  const { t } = useTranslation();
+  const fieldSchema = useFieldSchema();
+  const ctx = useActionContext();
+  const openMode = findSchema(ctx.fieldSchema);
+  const component = fieldSchema.parent.parent['x-component'];
+  const schema = { ...(afterSuccessSchema(t) as any) };
+  if (
+    ((!openMode || openMode === 'page') && (component as string).includes('Form')) ||
+    !(component as string).includes('Form')
+  ) {
+    delete schema.properties.popupClose;
+  }
+  return (
+    <SchemaSettingsModalItem
+      title={t('After successful submission')}
+      initialValues={fieldSchema?.['x-action-settings']?.['onSuccess']}
+      schema={{ ...schema } as ISchema}
+      onSubmit={(onSuccess) => {
+        fieldSchema['x-action-settings']['onSuccess'] = onSuccess;
+        dn.emit('patch', {
+          schema: {
+            ['x-uid']: fieldSchema['x-uid'],
+            'x-action-settings': fieldSchema['x-action-settings'],
+          },
+        });
+      }}
+    />
+  );
+}

--- a/packages/plugin-action-custom-request/src/client/components/CustomRequestAfter.tsx
+++ b/packages/plugin-action-custom-request/src/client/components/CustomRequestAfter.tsx
@@ -25,7 +25,7 @@ const afterSuccessSchema: (t) => ISchema = (t) => {
         'x-component-props': {},
       },
       downTitle: {
-        title: '{{t("Is DownLoad")}}',
+        title: '{{t("Setting Down Title")}}',
         default: 'document.docx',
         'x-decorator': 'FormItem',
         'x-component': 'Input',

--- a/packages/plugin-action-custom-request/src/client/components/CustomResponseTemplate.tsx
+++ b/packages/plugin-action-custom-request/src/client/components/CustomResponseTemplate.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Variable } from '@tachybase/client';
+
+import { useTranslation } from '../locale';
+
+export const CustomResponseTemplate: React.FC<{
+  value?: string;
+  onChange?: (value: string) => void;
+}> = (props) => {
+  const { t } = useTranslation();
+  const { value, onChange } = props;
+  const variableOptions = [
+    {
+      value: 'res.data',
+      label: t('Response body'),
+    },
+  ];
+
+  return (
+    <Variable.CodeMirror
+      value={value}
+      onChange={onChange}
+      scope={variableOptions}
+      fieldNames={{
+        value: 'value',
+        label: 'value',
+      }}
+    />
+  );
+};

--- a/packages/plugin-action-custom-request/src/client/hooks/useCustomizeRequestActionProps.ts
+++ b/packages/plugin-action-custom-request/src/client/hooks/useCustomizeRequestActionProps.ts
@@ -79,17 +79,7 @@ export const useCustomizeRequestActionProps = () => {
         if (xAction === 'customize:form:request') {
           setVisible?.(false);
         }
-        if (actionSchema?.['x-component-props']?.showData) {
-          modal.confirm({
-            title: 'Test Data',
-            content: `${JSON.stringify(res.data)}`,
-            okText: t('Confirm'),
-            cancelText: t('Cancel'),
-          });
-        } else {
-          if (!onSuccess?.successMessage) {
-            return;
-          }
+        if (actionSchema?.['x-component-props']?.successMessage) {
           let messageStr = parse(onSuccess?.successMessage)({ res });
           if (typeof messageStr !== 'string') {
             messageStr = JSON.stringify(messageStr);

--- a/packages/plugin-action-custom-request/src/client/hooks/useCustomizeRequestActionProps.ts
+++ b/packages/plugin-action-custom-request/src/client/hooks/useCustomizeRequestActionProps.ts
@@ -86,7 +86,7 @@ export const useCustomizeRequestActionProps = () => {
           }
           if (onSuccess?.manualClose) {
             modal.success({
-              title: messageStr,
+              title: compile(messageStr),
               onOk: async () => {
                 if (onSuccess?.redirecting && onSuccess?.redirectTo) {
                   if (isURL(onSuccess.redirectTo)) {

--- a/packages/plugin-action-custom-request/src/client/hooks/useCustomizeRequestActionProps.ts
+++ b/packages/plugin-action-custom-request/src/client/hooks/useCustomizeRequestActionProps.ts
@@ -8,7 +8,7 @@ import {
   useRecord,
 } from '@tachybase/client';
 import { useField, useFieldSchema, useForm } from '@tachybase/schema';
-import { isURL } from '@tachybase/utils/client';
+import { isURL, parse } from '@tachybase/utils/client';
 
 import { App } from 'antd';
 import { saveAs } from 'file-saver';
@@ -56,6 +56,7 @@ export const useCustomizeRequestActionProps = () => {
               appends: service.params[0]?.appends,
               data: formValues,
             },
+            successMessage: onSuccess.successMessage,
           },
           headers: {
             'X-Response-Type': onSuccess?.down ? 'blob' : 'json',
@@ -78,7 +79,6 @@ export const useCustomizeRequestActionProps = () => {
         if (xAction === 'customize:form:request') {
           setVisible?.(false);
         }
-
         if (actionSchema?.['x-component-props']?.showData) {
           modal.confirm({
             title: 'Test Data',
@@ -90,9 +90,13 @@ export const useCustomizeRequestActionProps = () => {
           if (!onSuccess?.successMessage) {
             return;
           }
+          let messageStr = parse(onSuccess?.successMessage)({ res });
+          if (typeof messageStr !== 'string') {
+            messageStr = JSON.stringify(messageStr);
+          }
           if (onSuccess?.manualClose) {
             modal.success({
-              title: compile(onSuccess?.successMessage),
+              title: messageStr,
               onOk: async () => {
                 if (onSuccess?.redirecting && onSuccess?.redirectTo) {
                   if (isURL(onSuccess.redirectTo)) {
@@ -104,7 +108,7 @@ export const useCustomizeRequestActionProps = () => {
               },
             });
           } else {
-            message.success(compile(onSuccess?.successMessage));
+            message.success(messageStr);
             if (onSuccess?.redirecting && onSuccess?.redirectTo) {
               if (isURL(onSuccess.redirectTo)) {
                 window.location.href = onSuccess.redirectTo;

--- a/packages/plugin-action-custom-request/src/client/hooks/useCustomizeRequestActionProps.ts
+++ b/packages/plugin-action-custom-request/src/client/hooks/useCustomizeRequestActionProps.ts
@@ -79,7 +79,7 @@ export const useCustomizeRequestActionProps = () => {
         if (xAction === 'customize:form:request') {
           setVisible?.(false);
         }
-        if (actionSchema?.['x-component-props']?.successMessage) {
+        if (onSuccess?.successMessage) {
           let messageStr = parse(onSuccess?.successMessage)({ res });
           if (typeof messageStr !== 'string') {
             messageStr = JSON.stringify(messageStr);

--- a/packages/plugin-action-custom-request/src/client/hooks/useCustomizeRequestActionProps.ts
+++ b/packages/plugin-action-custom-request/src/client/hooks/useCustomizeRequestActionProps.ts
@@ -57,6 +57,9 @@ export const useCustomizeRequestActionProps = () => {
               data: formValues,
             },
           },
+          headers: {
+            'X-Response-Type': onSuccess?.down ? 'blob' : 'json',
+          },
         })) as any;
         const headerContentType = res.headers.getContentType();
         if (onSuccess?.down) {

--- a/packages/plugin-action-custom-request/src/client/hooks/useCustomizeRequestActionProps.ts
+++ b/packages/plugin-action-custom-request/src/client/hooks/useCustomizeRequestActionProps.ts
@@ -98,7 +98,7 @@ export const useCustomizeRequestActionProps = () => {
               },
             });
           } else {
-            message.success(messageStr);
+            message.success(compile(messageStr));
             if (onSuccess?.redirecting && onSuccess?.redirectTo) {
               if (isURL(onSuccess.redirectTo)) {
                 window.location.href = onSuccess.redirectTo;

--- a/packages/plugin-action-custom-request/src/client/hooks/useCustomizeRequestActionProps.ts
+++ b/packages/plugin-action-custom-request/src/client/hooks/useCustomizeRequestActionProps.ts
@@ -107,6 +107,8 @@ export const useCustomizeRequestActionProps = () => {
               }
             }
           }
+        } else {
+          message.success(t('Request success'));
         }
       } finally {
         actionField.data.loading = false;

--- a/packages/plugin-action-custom-request/src/client/initializer/CustomRequestInitializer.tsx
+++ b/packages/plugin-action-custom-request/src/client/initializer/CustomRequestInitializer.tsx
@@ -3,10 +3,11 @@ import { BlockInitializer, useSchemaInitializerItem } from '@tachybase/client';
 import { uid } from '@tachybase/schema';
 
 import { useCustomRequestsResource } from '../hooks/useCustomRequestsResource';
+import { useTranslation } from '../locale';
 
 export const CustomRequestInitializer: React.FC<any> = (props) => {
   const customRequestsResource = useCustomRequestsResource();
-
+  const { t } = useTranslation();
   const schema = {
     title: '{{ t("Custom request") }}',
     'x-component': 'CustomRequestAction',
@@ -19,7 +20,7 @@ export const CustomRequestInitializer: React.FC<any> = (props) => {
       onSuccess: {
         manualClose: false,
         redirecting: false,
-        successMessage: '{{t("Request success")}}',
+        successMessage: t('Request success'),
       },
     },
   };

--- a/packages/plugin-action-custom-request/src/client/schemaSettings.ts
+++ b/packages/plugin-action-custom-request/src/client/schemaSettings.ts
@@ -64,7 +64,7 @@ export const customizeCustomRequestActionSettings = new SchemaSettings({
     },
     {
       name: 'afterSuccessfulSubmission',
-      Component: AfterSuccess,
+      Component: AfterSuccess, // 加下载配置,动态设置返回
     },
     {
       name: 'request settings',

--- a/packages/plugin-action-custom-request/src/client/schemaSettings.ts
+++ b/packages/plugin-action-custom-request/src/client/schemaSettings.ts
@@ -1,19 +1,15 @@
 import {
-  AfterSuccess,
   ButtonEditor,
-  IsDownLoad,
   RemoveButton,
   SchemaSettings,
   SchemaSettingsLinkageRules,
   SecondConFirm,
-  SettingDownTitle,
-  ShowData,
   useCollection,
   useSchemaToolbar,
 } from '@tachybase/client';
-import { useFieldSchema } from '@tachybase/schema';
 
 import { CustomRequestACL, CustomRequestSettingsItem } from './components/CustomRequestActionDesigner';
+import { CustomRequestAfter } from './components/CustomRequestAfter';
 
 export const customizeCustomRequestActionSettings = new SchemaSettings({
   name: 'actionSettings:customRequest',
@@ -46,25 +42,8 @@ export const customizeCustomRequestActionSettings = new SchemaSettings({
       Component: SecondConFirm,
     },
     {
-      name: 'isDownLoad',
-      Component: IsDownLoad,
-    },
-    {
-      name: 'settingDownTitle',
-      Component: SettingDownTitle,
-      useVisible() {
-        const fieldSchema = useFieldSchema();
-        const down = fieldSchema?.['x-action-settings']?.onSuccess?.down;
-        return down;
-      },
-    },
-    {
-      name: 'showData',
-      Component: ShowData,
-    },
-    {
       name: 'afterSuccessfulSubmission',
-      Component: AfterSuccess, // 加下载配置,动态设置返回
+      Component: CustomRequestAfter, // 加下载配置,动态设置返回
     },
     {
       name: 'request settings',

--- a/packages/plugin-action-custom-request/src/locale/zh-CN.json
+++ b/packages/plugin-action-custom-request/src/locale/zh-CN.json
@@ -16,6 +16,8 @@
   "Parameters": "参数",
   "Please configure the request settings first": "请先配置请求设置",
   "Request settings": "请求设置",
+  "Request success": "请求成功",
+  "Response body": "响应包体",
   "Roles": "角色",
   "Timeout config": "超时设置",
   "Title": "标题",

--- a/packages/plugin-action-custom-request/src/server/actions/send.ts
+++ b/packages/plugin-action-custom-request/src/server/actions/send.ts
@@ -164,7 +164,11 @@ export async function send(this: CustomRequestPlugin, ctx: Context, next: Next) 
 
   try {
     const res = await axios({ ...axiosRequestConfig, responseType: 'stream' });
-    ctx.set('Content-Type', `${res.headers['content-type']}`);
+    if (ctx.req.headers['x-response-type'] === 'blob') {
+      ctx.set('Content-Type', 'application/octet-stream');
+    } else {
+      ctx.set('Content-Type', `${res.headers['content-type']}`);
+    }
     ctx.set('Content-disposition', `${res.headers['content-disposition']}`);
     this.logger.info(`action-custom-request:send:${filterByTk} success`);
 


### PR DESCRIPTION
自定义请求
1.修改是否是下载,是否显示到请求成功后对话框
2.请求成功后对话框title翻译
3.支持弹窗显示包含返回的body模板语句
4.下载文件的之前不能下载的bug修改

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a customizable post-submission action interface for dynamic configuration of success notifications, downloads, and redirection.
	- Added an interactive response template editor with integrated code editing support.
	- Extended localization with additional translated messages, including "Request success" and "Response body".
	- Added new components for managing post-submission settings and response templates, enhancing user interaction.

- **Refactor**
	- Streamlined success message processing and form configuration with dynamic schema generation.
	- Enhanced response handling with adaptive content type settings for binary data.
	- Updated post-action settings by removing obsolete configuration options.
	- Modified schema generation to support localization for success messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->