### PR TITLE
fix: erorr for add primary key in order

### DIFF
--- a/packages/database/src/options-parser.ts
+++ b/packages/database/src/options-parser.ts
@@ -134,25 +134,6 @@ export class OptionsParser {
       sort = sort.split(',');
     }
 
-    let defaultSortField: Array<string> | string = this.model.primaryKeyAttribute;
-
-    if (Array.isArray(this.collection.filterTargetKey)) {
-      defaultSortField = this.collection.filterTargetKey;
-    }
-
-    if (!defaultSortField && this.collection.filterTargetKey && !Array.isArray(this.collection.filterTargetKey)) {
-      defaultSortField = this.collection.filterTargetKey;
-    }
-
-    if (defaultSortField && !this.options?.group) {
-      defaultSortField = lodash.castArray(defaultSortField);
-      for (const key of defaultSortField) {
-        if (!sort.includes(key)) {
-          sort.push(key);
-        }
-      }
-    }
-
     const orderParams = [];
 
     for (const sortKey of sort) {


### PR DESCRIPTION
在sort的地方默认加了主键排序

这里会有问题,其实不需要每个请求都加上这个主键
而且还会与工作流的聚合计算节点冲突

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Adjusted sorting behavior so that only explicitly provided sort criteria are applied. Previously, a default sort field was automatically determined and added. This update results in more predictable and intentional sorting outcomes for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->