### PR TITLE
fix: lack return next() in middlewares

### DIFF
--- a/packages/plugin-api-logs/src/server/hooks/afterUpdate.ts
+++ b/packages/plugin-api-logs/src/server/hooks/afterUpdate.ts
@@ -13,7 +13,7 @@ export async function handleUpdate(ctx: Context, next) {
   const changes = [];
   const { changed, data: dataBefore } = await getChanged(ctx, params.filterByTk);
   if (!changed) {
-    return;
+    return next();
   }
   changed.forEach((key: string) => {
     const field = collection.findField((field) => {
@@ -39,7 +39,7 @@ export async function handleUpdate(ctx: Context, next) {
     }
   });
   if (!changes.length) {
-    return;
+    return next();
   }
   await next();
   apilogsRepo.create({


### PR DESCRIPTION
在api-logs插件中缺少return next()的判断会导致忽略所有后面的中间件

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted update handling to ensure that all processing steps are executed consistently, even when no changes are detected. This enhancement maintains seamless execution of related operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->