### PR TITLE
fix: aggregation belongsToMany through

### DIFF
--- a/packages/plugin-block-charts/src/server/actions/query.ts
+++ b/packages/plugin-block-charts/src/server/actions/query.ts
@@ -232,12 +232,7 @@ export const parseFieldAndAssociations = async (ctx: Context, next: Next) => {
     collection,
   });
   const { where, include: filterInclude } = filterParser.toSequelizeParams();
-  const parsedFilterInclude = filterInclude?.map((item) => {
-    if (fields.get(item.association)?.type === 'belongsToMany') {
-      item.through = { attributes: [] };
-    }
-    return item;
-  });
+  addBelongsToManyThrough(filterInclude, collectionName, ctx.db);
 
   ctx.action.params.values = {
     ...ctx.action.params.values,
@@ -245,10 +240,27 @@ export const parseFieldAndAssociations = async (ctx: Context, next: Next) => {
     measures: parsedMeasures,
     dimensions: parsedDimensions,
     orders: parsedOrders,
-    include: [...include, ...(parsedFilterInclude || [])],
+    include: [...include, ...(filterInclude || [])],
   };
   await next();
 };
+
+// 针对多对多添加{ through: { attributes: [] } }
+function addBelongsToManyThrough(include, collectionName, db) {
+  const collection = db.getCollection(collectionName);
+  if (!collection) {
+    return;
+  }
+  const fields = collection.fields;
+  for (const item of include) {
+    if (fields.get(item.association)?.type === 'belongsToMany') {
+      item.through = { attributes: [] };
+    }
+    if (item.include) {
+      addBelongsToManyThrough(item.include, fields.get(item.association)?.target, db);
+    }
+  }
+}
 
 export const parseVariables = async (ctx: Context, next: Next) => {
   const { filter } = ctx.action.params.values;


### PR DESCRIPTION
聚合图表的时候如果遇到第二级多对多也要忽略attributes
要不然聚合计算会有问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined the way association filters are processed for chart data, leading to more consistent and reliable results when retrieving complex datasets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->