### PR TITLE
Perf/custom request

### DIFF
--- a/packages/plugin-action-custom-request/src/client/components/CustomRequestAfter.tsx
+++ b/packages/plugin-action-custom-request/src/client/components/CustomRequestAfter.tsx
@@ -44,14 +44,14 @@ const afterSuccessSchema: (t) => ISchema = (t) => {
         'x-decorator': 'FormItem',
         'x-component': CustomResponseTemplate,
         'x-component-props': {},
-        'x-reactions': {
-          dependencies: ['down'],
-          fulfill: {
-            state: {
-              visible: '{{!$deps[0]}}',
-            },
-          },
-        },
+        // 'x-reactions': {
+        //   dependencies: ['down'],
+        //   fulfill: {
+        //     state: {
+        //       visible: '{{!$deps[0]}}',
+        //     },
+        //   },
+        // },
       },
       popupClose: {
         title: '{{t("Popup close method")}}',

--- a/packages/plugin-action-custom-request/src/client/components/CustomRequestAfter.tsx
+++ b/packages/plugin-action-custom-request/src/client/components/CustomRequestAfter.tsx
@@ -26,7 +26,7 @@ const afterSuccessSchema: (t) => ISchema = (t) => {
       },
       downTitle: {
         title: '{{t("Setting Down Title")}}',
-        default: 'document.docx',
+        default: '{{ filename }}',
         'x-decorator': 'FormItem',
         'x-component': 'Input',
         'x-component-props': {},

--- a/packages/plugin-action-custom-request/src/client/components/CustomResponseTemplate.tsx
+++ b/packages/plugin-action-custom-request/src/client/components/CustomResponseTemplate.tsx
@@ -14,6 +14,10 @@ export const CustomResponseTemplate: React.FC<{
       value: 'res.data',
       label: t('Response body'),
     },
+    {
+      value: 'filename',
+      label: t('Download file name'),
+    },
   ];
 
   return (

--- a/packages/plugin-action-custom-request/src/client/initializer/CustomRequestInitializer.tsx
+++ b/packages/plugin-action-custom-request/src/client/initializer/CustomRequestInitializer.tsx
@@ -8,11 +8,9 @@ import {
 import { merge, uid } from '@tachybase/schema';
 
 import { useCustomRequestsResource } from '../hooks/useCustomRequestsResource';
-import { useTranslation } from '../locale';
 
 export const CustomRequestInitializer: React.FC<any> = (props) => {
   const customRequestsResource = useCustomRequestsResource();
-  const { t } = useTranslation();
   const schema = {
     title: '{{ t("Custom request") }}',
     'x-component': 'CustomRequestAction',
@@ -25,7 +23,7 @@ export const CustomRequestInitializer: React.FC<any> = (props) => {
       onSuccess: {
         manualClose: false,
         redirecting: false,
-        successMessage: t('Request success'),
+        successMessage: '{{ t("Request success") }}',
       },
     },
   };

--- a/packages/plugin-action-custom-request/src/locale/zh-CN.json
+++ b/packages/plugin-action-custom-request/src/locale/zh-CN.json
@@ -5,6 +5,7 @@
   "Add request header": "添加请求头",
   "Body": "请求体",
   "Custom Request": "自定义请求",
+  "Download file name": "下载文件名",
   "Enter description info": "输入描述信息",
   "Format": "格式化",
   "HTTP method": "HTTP 方法",

--- a/packages/plugin-action-custom-request/src/server/actions/send.ts
+++ b/packages/plugin-action-custom-request/src/server/actions/send.ts
@@ -171,7 +171,13 @@ export async function send(this: CustomRequestPlugin, ctx: Context, next: Next) 
     } else {
       ctx.set('Content-Type', `${res.headers['content-type']}`);
     }
-    ctx.set('Content-disposition', `${res.headers['content-disposition']}`);
+    if (res.headers['content-disposition']) {
+      ctx.set('Content-disposition', `${res.headers['content-disposition']}`);
+    } else if (ctx.req.headers['x-response-type'] === 'blob') {
+      // 从url最后获取文件名
+      const filename = new URL(requestUrl).pathname.split('/').pop() || '';
+      ctx.set('Content-Disposition', `attachment; filename="${filename}"`);
+    }
     this.logger.info(`action-custom-request:send:${filterByTk} success`);
 
     const readable = res.data as http.IncomingMessage;


### PR DESCRIPTION
自定义请求可以用下载文件的文件名作为提示文本

之前翻译做错了,应该用{{ t('xxx') }} 就好这样可以兼容不同翻译,毕竟初始化之后就不能改了

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Downloads now use dynamic filenames extracted from server responses, offering a personalized file-saving experience.
  - A new option for selecting the displayed download file name has been introduced.
  - Success notifications now reflect the actual file name.
  - Enhanced attachment handling ensures a reliable fallback when no filename is provided.
  - Expanded localization support updates download label terminology for improved multilingual clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->