### PR TITLE
fix: duplication button setting bar style

### DIFF
--- a/packages/plugin-action-duplicate/src/client/DuplicateAction.Settings.tsx
+++ b/packages/plugin-action-duplicate/src/client/DuplicateAction.Settings.tsx
@@ -318,68 +318,57 @@ function DuplicationMode() {
 
 const schemaSettingsItems: SchemaSettingsItemType[] = [
   {
-    type: 'subMenu',
-    name: 'Customize',
-    children: [
-      {
-        name: 'editButton',
-        Component: ActionDesigner.ButtonEditor,
-        useComponentProps() {
-          const { buttonEditorProps } = useSchemaToolbar();
-          return buttonEditorProps;
-        },
-      },
-      {
-        name: 'linkageRules',
-        Component: SchemaSettingsLinkageRules,
-        useComponentProps() {
-          const { name } = useCollection_deprecated();
-          const { linkageRulesProps } = useSchemaToolbar();
-          return {
-            ...linkageRulesProps,
-            collectionName: name,
-          };
-        },
-      },
-      {
-        name: 'duplicationMode',
-        Component: DuplicationMode,
-        useVisible() {
-          const fieldSchema = useFieldSchema();
-          const isDuplicateAction = fieldSchema['x-action'] === 'duplicate';
-          return isDuplicateAction;
-        },
-      },
-      {
-        name: 'openMode',
-        Component: SchemaSettingOpenModeSchemaItems,
-        useComponentProps() {
-          const fieldSchema = useFieldSchema();
-          const isPopupAction = [
-            'create',
-            'update',
-            'view',
-            'customize:popup',
-            'duplicate',
-            'customize:create',
-          ].includes(fieldSchema['x-action'] || '');
+    name: 'editButton',
+    Component: ActionDesigner.ButtonEditor,
+    useComponentProps() {
+      const { buttonEditorProps } = useSchemaToolbar();
+      return buttonEditorProps;
+    },
+  },
+  {
+    name: 'linkageRules',
+    Component: SchemaSettingsLinkageRules,
+    useComponentProps() {
+      const { name } = useCollection_deprecated();
+      const { linkageRulesProps } = useSchemaToolbar();
+      return {
+        ...linkageRulesProps,
+        collectionName: name,
+      };
+    },
+  },
+  {
+    name: 'duplicationMode',
+    Component: DuplicationMode,
+    useVisible() {
+      const fieldSchema = useFieldSchema();
+      const isDuplicateAction = fieldSchema['x-action'] === 'duplicate';
+      return isDuplicateAction;
+    },
+  },
+  {
+    name: 'openMode',
+    Component: SchemaSettingOpenModeSchemaItems,
+    useComponentProps() {
+      const fieldSchema = useFieldSchema();
+      const isPopupAction = ['create', 'update', 'view', 'customize:popup', 'duplicate', 'customize:create'].includes(
+        fieldSchema['x-action'] || '',
+      );
 
-          return {
-            openMode: isPopupAction,
-            openSize: isPopupAction,
-          };
-        },
-      },
-      {
-        name: 'remove',
-        sort: 100,
-        Component: ActionDesigner.RemoveButton as any,
-        useComponentProps() {
-          const { removeButtonProps } = useSchemaToolbar();
-          return removeButtonProps;
-        },
-      },
-    ],
+      return {
+        openMode: isPopupAction,
+        openSize: isPopupAction,
+      };
+    },
+  },
+  {
+    name: 'remove',
+    sort: 100,
+    Component: ActionDesigner.RemoveButton as any,
+    useComponentProps() {
+      const { removeButtonProps } = useSchemaToolbar();
+      return removeButtonProps;
+    },
   },
 ];
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified the duplicate action settings layout by removing an extra nested menu layer.
	- All configuration options (editing, linkage, duplication mode, open mode, removal) are now directly accessible for a more streamlined experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->