### PR TITLE
fix: env-secrets built-in, api-logs error in upgrade

### DIFF
--- a/packages/module-event-source/src/server/constants.ts
+++ b/packages/module-event-source/src/server/constants.ts
@@ -1,2 +1,2 @@
 export const EVENT_SOURCE_COLLECTION = 'webhooks';
-export const EVENT_SOURCE_REALTIME = process.env.EVENT_SOURCE_REALTIME ? true : false;
+export const EVENT_SOURCE_REALTIME = process.env.EVENT_SOURCE_REALTIME === '0' ? false : true;

--- a/packages/module-event-source/src/server/webhooks/Plugin.ts
+++ b/packages/module-event-source/src/server/webhooks/Plugin.ts
@@ -133,7 +133,7 @@ export class PluginWebhook extends Plugin {
     this.db.on(`${EVENT_SOURCE_COLLECTION}.afterUpdate`, async (model: EventSourceModel, options) => {
       const trigger = this.triggers.get(model.type);
       if (!trigger?.getRealTimeRefresh()) {
-        for (const key of ['enabled', 'type', 'options']) {
+        for (const key of ['enabled', 'type', 'options', 'code', 'workflowKey']) {
           if (model.changed(key)) {
             this.changed = true;
             break;

--- a/packages/plugin-adapter-bullmq/src/server/plugin.ts
+++ b/packages/plugin-adapter-bullmq/src/server/plugin.ts
@@ -27,6 +27,10 @@ export class PluginAdapterBullmqServer extends Plugin {
     const EXTENSION_UI_BASE_PATH = process.env.EXTENSION_UI_BASE_PATH || '/adapters/';
     serverAdapter.setBasePath(EXTENSION_UI_BASE_PATH + 'mqui');
     this.app.use(serverAdapter.registerPlugin(), { before: 'bodyParser' });
+
+    this.app.on('beforeStop', async () => {
+      await defaultQueue?.close?.();
+    });
   }
 
   async install() {}

--- a/packages/plugin-api-logs/src/server/plugin.ts
+++ b/packages/plugin-api-logs/src/server/plugin.ts
@@ -13,14 +13,14 @@ export class PluginApiLogsServer extends Plugin {
   apiFilter: ApiFilter = null;
 
   async addApiListener() {
-    this.apiFilter = new ApiFilter(this.db);
     this.app.on('afterStart', async () => {
+      this.apiFilter = new ApiFilter(this.db);
       await this.apiFilter.load();
     });
     this.app.resourcer.use(
       async (ctx: Context, next) => {
         const { actionName, resourceName, params } = ctx.action;
-        if (!this.apiFilter.check(resourceName, actionName)) {
+        if (!this.apiFilter?.check(resourceName, actionName)) {
           return next();
         }
         if (actionName === 'update') {

--- a/packages/preset-tachybase/src/server/index.ts
+++ b/packages/preset-tachybase/src/server/index.ts
@@ -22,6 +22,7 @@ export class PresetTachyBase extends Plugin {
     'web',
     'worker-thread',
     'workflow',
+    'env-secrets',
   ];
 
   get builtInPlugins() {
@@ -49,7 +50,6 @@ export class PresetTachyBase extends Plugin {
     ['log-viewer', '0.22.67', true],
     ['otp', '0.22.67', true],
     ['full-text-search', '0.23.24', true],
-    ['env-secrets', '0.23.45', true],
     // default disable
     ['adapter-bullmq', '0.21.76', false],
     ['adapter-red-node', '0.22.8', false],


### PR DESCRIPTION
将环境变量插件提到内置插件
api-logs 在upgrade命令运行的时候会报错

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced built-in support for managing environment secrets, streamlining the plugin configuration.
	- Enhanced change detection in event handling to monitor additional model properties.
- **Bug Fixes**
	- Improved the startup initialization sequence to enhance stability and prevent potential runtime issues.
	- Added a cleanup mechanism for the queue during server shutdown to ensure proper resource management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->