### PR TITLE
feat: bind work before submit success

### DIFF
--- a/packages/client/src/block-provider/hooks/index.ts
+++ b/packages/client/src/block-provider/hooks/index.ts
@@ -268,6 +268,24 @@ const useJumpDetails = () => {
   };
 };
 
+export function getAfterWorkflows(triggerWorkflows: any[]): string | undefined {
+  if (!triggerWorkflows?.length) {
+    return undefined;
+  }
+  return triggerWorkflows
+    .map((row) => [row.workflowKey, row.context].filter((row) => row && row.order !== 'before').join('!'))
+    .join(',');
+}
+
+export function getBeforeWorkflows(triggerWorkflows: any[]): string | undefined {
+  if (!triggerWorkflows?.length) {
+    return undefined;
+  }
+  return triggerWorkflows
+    .map((row) => [row.workflowKey, row.context].filter((row) => row && row.order === 'before').join('!'))
+    .join(',');
+}
+
 export const useCreateActionProps = () => {
   const record = useCollectionRecord();
   const form = useForm();
@@ -298,9 +316,8 @@ export const useCreateActionProps = () => {
           values: await collectValues(),
           filterKeys: filterKeys,
           // TODO(refactor): should change to inject by plugin
-          triggerWorkflows: triggerWorkflows?.length
-            ? triggerWorkflows.map((row) => [row.workflowKey, row.context].filter(Boolean).join('!')).join(',')
-            : undefined,
+          triggerWorkflows: getAfterWorkflows(triggerWorkflows),
+          beforeWorkflows: getBeforeWorkflows(triggerWorkflows),
           updateAssociationValues,
         });
         actionField.data.loading = false;
@@ -433,9 +450,8 @@ export const useAssociationCreateActionProps = () => {
           },
           filterKeys: filterKeys,
           // TODO(refactor): should change to inject by plugin
-          triggerWorkflows: triggerWorkflows?.length
-            ? triggerWorkflows.map((row) => [row.workflowKey, row.context].filter(Boolean).join('!')).join(',')
-            : undefined,
+          triggerWorkflows: getAfterWorkflows(triggerWorkflows),
+          beforeWorkflows: getBeforeWorkflows(triggerWorkflows),
         });
         actionField.data.loading = false;
         actionField.data.data = data;
@@ -670,9 +686,8 @@ export const useCustomizeUpdateActionProps = () => {
         filterByTk,
         values: { ...assignedValues },
         // TODO(refactor): should change to inject by plugin
-        triggerWorkflows: triggerWorkflows?.length
-          ? triggerWorkflows.map((row) => [row.workflowKey, row.context].filter(Boolean).join('!')).join(',')
-          : undefined,
+        triggerWorkflows: getAfterWorkflows(triggerWorkflows),
+        beforeWorkflows: getBeforeWorkflows(triggerWorkflows),
       });
       service?.refresh?.();
       if (!(resource instanceof TableFieldResource)) {
@@ -892,9 +907,8 @@ export const useUpdateActionProps = () => {
           ...data,
           updateAssociationValues,
           // TODO(refactor): should change to inject by plugin
-          triggerWorkflows: triggerWorkflows?.length
-            ? triggerWorkflows.map((row) => [row.workflowKey, row.context].filter(Boolean).join('!')).join(',')
-            : undefined,
+          triggerWorkflows: getAfterWorkflows(triggerWorkflows),
+          beforeWorkflows: getBeforeWorkflows(triggerWorkflows),
         });
         actionField.data.loading = false;
         __parent?.service?.refresh?.();
@@ -945,9 +959,8 @@ export const useDestroyActionProps = () => {
       await resource.destroy({
         filterByTk,
         // TODO(refactor): should change to inject by plugin
-        triggerWorkflows: triggerWorkflows?.length
-          ? triggerWorkflows.map((row) => [row.workflowKey, row.context].filter(Boolean).join('!')).join(',')
-          : undefined,
+        triggerWorkflows: getAfterWorkflows(triggerWorkflows),
+        beforeWorkflows: getBeforeWorkflows(triggerWorkflows),
         ...data,
       });
 

--- a/packages/client/src/block-provider/hooks/index.ts
+++ b/packages/client/src/block-provider/hooks/index.ts
@@ -273,7 +273,8 @@ export function getAfterWorkflows(triggerWorkflows: any[]): string | undefined {
     return undefined;
   }
   return triggerWorkflows
-    .map((row) => [row.workflowKey, row.context].filter((row) => row && row.order !== 'before').join('!'))
+    .filter((row) => row && row.order !== 'before')
+    .map((row) => [row.workflowKey, row.context].join('!'))
     .join(',');
 }
 
@@ -282,7 +283,8 @@ export function getBeforeWorkflows(triggerWorkflows: any[]): string | undefined 
     return undefined;
   }
   return triggerWorkflows
-    .map((row) => [row.workflowKey, row.context].filter((row) => row && row.order === 'before').join('!'))
+    .filter((row) => row && row.order === 'before')
+    .map((row) => [row.workflowKey, row.context].join('!'))
     .join(',');
 }
 

--- a/packages/client/src/modules/actions/delete/deleteActionSettings.tsx
+++ b/packages/client/src/modules/actions/delete/deleteActionSettings.tsx
@@ -1,7 +1,9 @@
+import { isValid, useFieldSchema } from '@tachybase/schema';
+
 import { useSchemaToolbar } from '../../../application';
 import { SchemaSettings } from '../../../application/schema-settings/SchemaSettings';
 import { useCollection_deprecated } from '../../../collection-manager';
-import { ButtonEditor, SecondConFirm } from '../../../schema-component/antd/action/Action.Designer';
+import { ButtonEditor, SecondConFirm, WorkflowConfig } from '../../../schema-component/antd/action/Action.Designer';
 import { SchemaSettingsLinkageRules } from '../../../schema-settings';
 
 export const deleteActionSettings = new SchemaSettings({
@@ -30,6 +32,14 @@ export const deleteActionSettings = new SchemaSettings({
     {
       name: 'secondConFirm',
       Component: SecondConFirm,
+    },
+    {
+      name: 'workflowConfig',
+      Component: WorkflowConfig,
+      useVisible() {
+        const fieldSchema = useFieldSchema();
+        return isValid(fieldSchema?.['x-action-settings']?.triggerWorkflows);
+      },
     },
     {
       name: 'delete',

--- a/packages/client/src/schema-component/antd/action/Action.Designer.tsx
+++ b/packages/client/src/schema-component/antd/action/Action.Designer.tsx
@@ -441,18 +441,44 @@ export function WorkflowConfig() {
   const buttonAction = fieldSchema['x-action'];
 
   const description = {
-    submit: t('Workflow will be triggered before or after submitting succeeded based on workflow type.', {
+    submit: t('Workflow will be triggered before or after submitting succeeded.', {
       ns: 'workflow',
     }),
-    'customize:save': t('Workflow will be triggered before or after submitting succeeded based on workflow type.', {
+    'customize:save': t('Workflow will be triggered before or after submitting succeeded.', {
       ns: 'workflow',
     }),
     'customize:triggerWorkflows': t(
       'Workflow will be triggered directly once the button clicked, without data saving.',
       { ns: 'workflow' },
     ),
-    destroy: t('Workflow will be triggered before deleting succeeded.', { ns: 'workflow' }),
+    destroy: t('Workflow will be triggered before or after submitting succeeded.', { ns: 'workflow' }),
   }[fieldSchema?.['x-action']];
+
+  let orderColumn = {};
+  // 暂定删除也可以指定顺序
+  if (['submit', 'customize:save', 'destroy'].includes(fieldSchema?.['x-action'])) {
+    orderColumn = {
+      order: {
+        type: 'void',
+        'x-component': 'ArrayTable.Column',
+        'x-component-props': {
+          title: t('Sequentially', { ns: 'workflow' }),
+        },
+        properties: {
+          order: {
+            type: 'string',
+            'x-decorator': 'FormItem',
+            'x-component': 'Select',
+            default: 'after',
+            enum: [
+              { label: t('After'), value: 'after' },
+              { label: t('Before'), value: 'before' },
+            ],
+          },
+        },
+      },
+    };
+  }
 
   return (
     <SchemaSettingsActionModalItem
@@ -541,6 +567,7 @@ export function WorkflowConfig() {
                       },
                     },
                   },
+                  ...orderColumn,
                   operations: {
                     type: 'void',
                     'x-component': 'ArrayTable.Column',

--- a/packages/module-workflow/src/client/features/omni-trigger/usage/hooks.tsx
+++ b/packages/module-workflow/src/client/features/omni-trigger/usage/hooks.tsx
@@ -1,5 +1,7 @@
 import React, { useContext } from 'react';
 import {
+  getAfterWorkflows,
+  getBeforeWorkflows,
   isVariable,
   transformVariableValue,
   useBlockRequestContext,
@@ -137,22 +139,14 @@ export const usePropsAPIRegular = () => {
             if (isUpdateSelected) {
               await resource.trigger({
                 filterByTk: selectedRecordKeys,
-                triggerWorkflows:
-                  triggerWorkflows && triggerWorkflows.length > 0
-                    ? triggerWorkflows
-                        .map((workflow) => [workflow.workflowKey, workflow.context].filter(Boolean).join('!'))
-                        .join(',')
-                    : [],
+                triggerWorkflows: getAfterWorkflows(triggerWorkflows),
+                beforeWorkflows: getBeforeWorkflows(triggerWorkflows),
               });
             } else {
               await resource.trigger({
                 filter,
-                triggerWorkflows:
-                  triggerWorkflows && triggerWorkflows.length > 0
-                    ? triggerWorkflows
-                        .map((workflow) => [workflow.workflowKey, workflow.context].filter(Boolean).join('!'))
-                        .join(',')
-                    : [],
+                triggerWorkflows: getAfterWorkflows(triggerWorkflows),
+                beforeWorkflows: getBeforeWorkflows(triggerWorkflows),
               });
             }
           }

--- a/packages/module-workflow/src/client/features/omni-trigger/useFormWorkflowCustomActionProps.tsx
+++ b/packages/module-workflow/src/client/features/omni-trigger/useFormWorkflowCustomActionProps.tsx
@@ -1,4 +1,6 @@
 import {
+  getAfterWorkflows,
+  getBeforeWorkflows,
   useActionContext,
   useBlockRequestContext,
   useCollectValuesToSubmit,
@@ -37,11 +39,8 @@ export function useFormWorkflowCustomActionProps() {
           const result = await resource.trigger({
             values,
             filterByTk,
-            triggerWorkflows: triggerWorkflows?.length
-              ? triggerWorkflows
-                  .map((workflow) => [workflow.workflowKey, workflow.context].filter(Boolean).join('!'))
-                  .join(',')
-              : undefined,
+            triggerWorkflows: getAfterWorkflows(triggerWorkflows),
+            beforeWorkflows: getBeforeWorkflows(triggerWorkflows),
           });
           _field.data.data = result;
           __parent?.service?.refresh?.();

--- a/packages/module-workflow/src/client/features/omni-trigger/useRecordWorkflowCustomTriggerActionProps.tsx
+++ b/packages/module-workflow/src/client/features/omni-trigger/useRecordWorkflowCustomTriggerActionProps.tsx
@@ -1,4 +1,11 @@
-import { useActionContext, useBlockRequestContext, useCompile, useFilterByTk } from '@tachybase/client';
+import {
+  getAfterWorkflows,
+  getBeforeWorkflows,
+  useActionContext,
+  useBlockRequestContext,
+  useCompile,
+  useFilterByTk,
+} from '@tachybase/client';
 import { useField, useFieldSchema } from '@tachybase/schema';
 import { isURL } from '@tachybase/utils/client';
 
@@ -21,11 +28,8 @@ export function useRecordWorkflowCustomTriggerActionProps() {
       try {
         await resource.trigger({
           filterByTk: filterByTk,
-          triggerWorkflows: triggerWorkflows?.length
-            ? triggerWorkflows
-                .map((workflow) => [workflow.workflowKey, workflow.context].filter(Boolean).join('!'))
-                .join(',')
-            : undefined,
+          triggerWorkflows: getAfterWorkflows(triggerWorkflows),
+          beforeWorkflows: getBeforeWorkflows(triggerWorkflows),
         });
         callback?.();
         setVisible?.(false);

--- a/packages/module-workflow/src/client/hooks/useTriggerWorkflowActionProps.ts
+++ b/packages/module-workflow/src/client/hooks/useTriggerWorkflowActionProps.ts
@@ -1,4 +1,6 @@
 import {
+  getAfterWorkflows,
+  getBeforeWorkflows,
   useActionContext,
   useAPIClient,
   useBlockRequestContext,
@@ -40,9 +42,8 @@ export function useTriggerWorkflowsActionProps() {
           values,
           filterKeys: filterKeys,
           // TODO(refactor): should change to inject by plugin
-          triggerWorkflows: triggerWorkflows?.length
-            ? triggerWorkflows.map((row) => [row.workflowKey, row.context].filter(Boolean).join('!')).join(',')
-            : undefined,
+          triggerWorkflows: getAfterWorkflows(triggerWorkflows),
+          beforeWorkflows: getBeforeWorkflows(triggerWorkflows),
         });
         actionField.data.loading = false;
         actionField.data.data = data;
@@ -96,9 +97,8 @@ export function useRecordTriggerWorkflowsActionProps() {
         await api.resource('workflows').trigger({
           values: record,
           // TODO(refactor): should change to inject by plugin
-          triggerWorkflows: triggerWorkflows?.length
-            ? triggerWorkflows.map((row) => [row.workflowKey, row.context].filter(Boolean).join('!')).join(',')
-            : undefined,
+          triggerWorkflows: getAfterWorkflows(triggerWorkflows),
+          beforeWorkflows: getBeforeWorkflows(triggerWorkflows),
         });
         __parent?.service?.refresh?.();
         setVisible?.(false);

--- a/packages/module-workflow/src/locale/zh-CN.json
+++ b/packages/module-workflow/src/locale/zh-CN.json
@@ -405,6 +405,7 @@
   "Workflow todos": "工作流待办",
   "Workflow will be triggered before deleting succeeded.": "删除成功之前触发工作流。",
   "Workflow will be triggered before or after submitting succeeded based on workflow type.": "工作流会基于其类型在提交成功之前或之后触发。",
+  "Workflow will be triggered before or after submitting succeeded.": "工作流会在提交成功之前或之后触发。",
   "Workflow will be triggered directly once the button clicked, without data saving.": "按钮点击后直接触发工作流，但不会保存数据。",
   "comment": "备注",
   "concat": "连接",

--- a/packages/plugin-workflow-approval/src/locale/zh-CN.json
+++ b/packages/plugin-workflow-approval/src/locale/zh-CN.json
@@ -384,6 +384,7 @@
   "Workflow todos": "工作流待办",
   "Workflow will be triggered before deleting succeeded.": "删除成功之前触发工作流。",
   "Workflow will be triggered before or after submitting succeeded based on workflow type.": "工作流会基于其类型在提交成功之前或之后触发。",
+  "Workflow will be triggered before or after submitting succeeded.": "工作流会在提交成功之前或之后触发。",
   "Workflow will be triggered directly once the button clicked, without data saving.": "按钮点击后直接触发工作流，但不会保存数据。",
   "comment": "备注",
   "concat": "连接",

--- a/packages/plugin-workflow-approval/src/server/triggers/Approval.ts
+++ b/packages/plugin-workflow-approval/src/server/triggers/Approval.ts
@@ -158,8 +158,11 @@ export default class ApprovalTrigger extends Trigger {
     const {
       resourceName,
       actionName,
-      params: { triggerWorkflows },
+      params: { triggerWorkflows, beforeWorkflows },
     } = context.action;
+    if (beforeWorkflows) {
+      this.collectionTriggerAction(context, beforeWorkflows);
+    }
     if (resourceName === 'workflows' && actionName === 'trigger') {
       return this.workflowTriggerAction(context, next);
     }
@@ -167,7 +170,7 @@ export default class ApprovalTrigger extends Trigger {
     if (!triggerWorkflows || !['create', 'update'].includes(actionName)) {
       return;
     }
-    this.collectionTriggerAction(context);
+    this.collectionTriggerAction(context, triggerWorkflows);
   };
   constructor(workflow) {
     super(workflow);
@@ -228,11 +231,10 @@ export default class ApprovalTrigger extends Trigger {
       });
     });
   }
-  async collectionTriggerAction(context) {
-    const { triggerWorkflows = '' } = context.action.params;
+  async collectionTriggerAction(context, workflowList) {
     const dataSourceHeader = context.get('x-data-source') || 'main';
     const approvalRepo = this.workflow.db.getRepository('approvals');
-    const triggers = triggerWorkflows.split(',').map((trigger) => trigger.split('!'));
+    const triggers = workflowList.split(',').map((trigger) => trigger.split('!'));
     const triggersKeysMap = new Map(triggers);
     const workflows = Array.from(this.workflow.enabledCache.values()).filter(
       (item) => item.type === ApprovalTrigger.TYPE && triggersKeysMap.has(item.key),


### PR DESCRIPTION
支持绑定工作流自定义在事务成功之前还是之后触发

自定义触发工作流不支持

支持提交按钮, 删除按钮 和保存数据
<img width="762" alt="image" src="https://github.com/user-attachments/assets/afe6087e-693b-4373-864c-3f482e35a621" />

<img width="910" alt="image" src="https://github.com/user-attachments/assets/d24cda2d-7af2-4e75-b770-4d9ce778506d" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new functions for processing workflow triggers, enhancing clarity and organization.
	- Added a new workflow configuration component to delete action settings.
	- Expanded functionality to allow users to specify the order of workflow actions (Before/After) in various contexts.

- **Documentation**
	- Updated UI descriptions and locale texts for clearer communication regarding workflow triggering conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->