### PR TITLE
fix: association table acl error

### DIFF
--- a/packages/acl/src/acl.ts
+++ b/packages/acl/src/acl.ts
@@ -353,7 +353,19 @@ export class ACL extends EventEmitter {
 
     return async function ACLMiddleware(ctx, next) {
       const roleName = ctx.state.currentRole || 'anonymous';
-      const { resourceName, actionName } = ctx.action;
+      const { resourceName: rawResourceName, actionName } = ctx.action;
+
+      let resourceName = rawResourceName;
+      if (rawResourceName.includes('.')) {
+        resourceName = rawResourceName.split('.').pop();
+      }
+
+      if (ctx.getCurrentRepository) {
+        const currentRepository = ctx.getCurrentRepository();
+        if (currentRepository && currentRepository.targetCollection) {
+          resourceName = ctx.getCurrentRepository().targetCollection.name;
+        }
+      }
 
       ctx.can = (options: Omit<CanArgs, 'role'>) => {
         const canResult = acl.can({ role: roleName, ...options, ctx });

--- a/packages/data-source/src/data-source-manager.ts
+++ b/packages/data-source/src/data-source-manager.ts
@@ -25,17 +25,15 @@ export class DataSourceManager {
 
   middleware() {
     return async (ctx, next) => {
-      const name = ctx.get('x-data-source');
-      if (name) {
-        if (this.dataSources.has(name)) {
-          const ds = this.dataSources.get(name);
-          ctx.dataSource = ds;
-          return ds.middleware(this.middlewares)(ctx, next);
-        } else {
-          ctx.throw(`data source ${name} does not exist`);
-        }
+      const name = ctx.get('x-data-source') || 'main';
+      if (!this.dataSources.has(name)) {
+        ctx.throw(`data source ${name} does not exist`);
       }
-      await next();
+      const ds = this.dataSources.get(name);
+      ctx.dataSource = ds;
+
+      const composedFn = ds.middleware(this.middlewares);
+      return composedFn(ctx, next);
     };
   }
 }

--- a/packages/server/src/helper.ts
+++ b/packages/server/src/helper.ts
@@ -98,7 +98,7 @@ export function registerMiddlewares(app: Application, options: ApplicationOption
 
   app.use(db2resource, { tag: 'db2resource', after: 'dataWrapping' });
   app.use(app.resourcer.restApiMiddleware({ skipIfDataSourceExists: true }), { tag: 'restApi', after: 'db2resource' });
-  app.use(app.dataSourceManager.middleware(), { tag: 'dataSource', after: 'restApi' });
+  app.use(app.dataSourceManager.middleware(), { tag: 'dataSource', after: 'dataWrapping', before: 'restApi' });
 }
 
 export const createAppProxy = (app: Application) => {


### PR DESCRIPTION
通过关联关系比如/api/product/394/category:get?filterByTk=394 之前一直有问题
限定了acl之后这里需要修改

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved resource determination in access control, ensuring more accurate interpretation of incoming actions.
	- Streamlined data source selection with a default fallback and simplified error handling for smoother operations.
	- Adjusted the request processing order to optimize middleware execution for enhanced reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->