### PR TITLE
fix: acl dataSource:list acl error

### DIFF
--- a/packages/module-acl/src/server/server.ts
+++ b/packages/module-acl/src/server/server.ts
@@ -53,59 +53,6 @@ export class PluginACL extends Plugin {
     this.associationFieldsActions[associationType] = value;
   }
 
-  registerAssociationFieldsActions() {
-    // if grant create action to role, it should
-    // also grant add action and association target's view action
-
-    this.registerAssociationFieldAction('hasOne', {
-      view: {
-        associationActions: ['list', 'get', 'view'],
-      },
-      create: {
-        associationActions: ['create', 'set'],
-      },
-      update: {
-        associationActions: ['update', 'remove', 'set'],
-      },
-    });
-
-    this.registerAssociationFieldAction('hasMany', {
-      view: {
-        associationActions: ['list', 'get', 'view'],
-      },
-      create: {
-        associationActions: ['create', 'set', 'add'],
-      },
-      update: {
-        associationActions: ['update', 'remove', 'set'],
-      },
-    });
-
-    this.registerAssociationFieldAction('belongsTo', {
-      view: {
-        associationActions: ['list', 'get', 'view'],
-      },
-      create: {
-        associationActions: ['create', 'set'],
-      },
-      update: {
-        associationActions: ['update', 'remove', 'set'],
-      },
-    });
-
-    this.registerAssociationFieldAction('belongsToMany', {
-      view: {
-        associationActions: ['list', 'get', 'view'],
-      },
-      create: {
-        associationActions: ['create', 'set', 'add'],
-      },
-      update: {
-        associationActions: ['update', 'remove', 'set', 'toggle'],
-      },
-    });
-  }
-
   async writeResourceToACL(resourceModel: RoleResourceModel, transaction) {
     await resourceModel.writeToACL({
       acl: this.acl,
@@ -221,8 +168,6 @@ export class PluginACL extends Plugin {
         };
       }
     });
-
-    this.registerAssociationFieldsActions();
 
     this.app.resourcer.define(availableActionResource);
     this.app.resourcer.define(roleCollectionsResource);

--- a/packages/module-acl/src/server/server.ts
+++ b/packages/module-acl/src/server/server.ts
@@ -183,6 +183,13 @@ export class PluginACL extends Plugin {
         'uiSchemas:getProperties',
         'roles.menuUiSchemas:*',
         'roles.users:*',
+        'dataSources.roles:*',
+        'dataSources:list',
+        'dataSources.rolesResourcesScopes:*',
+        'roles.dataSourcesCollections:*',
+        'roles.dataSourceResources:*',
+        'dataSourcesRolesResourcesScopes:*',
+        'rolesResourcesScopes:*',
       ],
     });
 

--- a/packages/module-app-info/src/server/server.ts
+++ b/packages/module-app-info/src/server/server.ts
@@ -41,7 +41,7 @@ export class SystemSettingsPlugin extends Plugin {
     }
 
     this.app.acl.registerSnippet({
-      name: `pm.${this.name}.system-settings`,
+      name: `pm.system-settings.system-settings`,
       actions: ['systemSettings:put'],
     });
   }

--- a/packages/module-data-source/src/client/index.tsx
+++ b/packages/module-data-source/src/client/index.tsx
@@ -25,6 +25,7 @@ export class PluginDataSourceManagerClient extends Plugin {
       title: `{{t("Collections", { ns: "${NAMESPACE}" })}}`,
       icon: 'DatabaseOutlined',
       Component: MainDataSourceManager,
+      aclSnippet: 'pm.database-connections.collections',
       pluginKey: 'collections',
       sort: -70,
     });
@@ -37,11 +38,13 @@ export class PluginDataSourceManagerClient extends Plugin {
       aclSnippet: 'pm.database-connections.manager',
       sort: -70,
     });
+    // TODO: 这个子页面也需要配置,但是title会共享,会导致出现在配置页面为"主数据源"
     this.app.systemSettingsManager.add(`data-modeling.${NAMESPACE}/:name`, {
       title: <BreadcumbTitle />,
       Component: CollectionManagerPage,
       groupKey: `data-modeling.${NAMESPACE}`,
       pluginKey: NAMESPACE,
+      aclSnippet: 'pm.database-connections.manager',
     });
 
     this.app.dataSourceManager.addDataSources(this.getThirdDataSource.bind(this), ThirdDataSource);

--- a/packages/module-data-source/src/server/plugin.ts
+++ b/packages/module-data-source/src/server/plugin.ts
@@ -135,6 +135,9 @@ export class PluginDataSourceManagerServer extends Plugin {
           }
 
           const items = lodash.get(ctx, dataPath);
+          if (!Array.isArray(items)) {
+            return;
+          }
 
           lodash.set(
             ctx,
@@ -158,7 +161,7 @@ export class PluginDataSourceManagerServer extends Plugin {
           );
         }
       },
-      { tag: 'processDataSourcesList' },
+      { tag: 'processDataSourcesList', before: 'dataWrapping' },
     );
 
     const plugin = this;
@@ -540,16 +543,8 @@ export class PluginDataSourceManagerServer extends Plugin {
     );
 
     this.app.acl.registerSnippet({
-      name: `pm.${this.name}`,
-      actions: [
-        'dataSources:*',
-        'roles.dataSourceResources',
-        'collections:*',
-        'collections.fields:*',
-        'dbViews:*',
-        'collectionCategories:*',
-        'sqlCollection:*',
-      ],
+      name: 'pm.database-connections.collections',
+      actions: ['collections:*', 'collections.fields:*', 'collectionCategories:*'],
     });
 
     this.app.acl.allow('dataSources', 'listEnabled', 'loggedIn');

--- a/packages/module-env-secrets/src/client/plugin.tsx
+++ b/packages/module-env-secrets/src/client/plugin.tsx
@@ -10,6 +10,7 @@ export class PluginEnvironmentVariablesClient extends Plugin {
       title: this.t('Variables and secrets'),
       icon: 'TableOutlined',
       Component: EnvironmentPage,
+      aclSnippet: 'pm.system-services.env-secrets',
     });
     this.app.addGlobalVar('$env', useGetEnvironmentVariables);
     this.app.use(EnvironmentVariablesAndSecretsProvider);

--- a/packages/module-env-secrets/src/server/plugin.ts
+++ b/packages/module-env-secrets/src/server/plugin.ts
@@ -28,7 +28,7 @@ export class PluginEnvironmentVariablesServer extends Plugin {
   registerACL() {
     this.app.acl.allow('environmentVariables', 'list', 'loggedIn');
     this.app.acl.registerSnippet({
-      name: `pm.${this.name}`,
+      name: `pm.system-services.env-secrets`,
       actions: ['environmentVariables:*', 'app:refresh'],
     });
   }

--- a/packages/module-event-source/src/server/webhooks/Plugin.ts
+++ b/packages/module-event-source/src/server/webhooks/Plugin.ts
@@ -77,7 +77,7 @@ export class PluginWebhook extends Plugin {
 
     this.app.acl.registerSnippet({
       name: 'pm.business-components.event-source',
-      actions: ['webhooks:*'],
+      actions: ['webhooks:*', 'workflows:*'],
     });
   }
 

--- a/packages/module-file/src/server/server.ts
+++ b/packages/module-file/src/server/server.ts
@@ -76,7 +76,7 @@ export default class PluginFileManager extends Plugin {
     });
 
     this.app.acl.registerSnippet({
-      name: `pm.${this.name}.storages`,
+      name: `pm.file-manager.storages`,
       actions: ['storages:*'],
     });
 

--- a/packages/module-multi-app/src/client/index.tsx
+++ b/packages/module-multi-app/src/client/index.tsx
@@ -20,7 +20,7 @@ export class MultiAppManagerPlugin extends Plugin {
       title: i18nText('Multi-app manager'),
       icon: 'AppstoreOutlined',
       Component: AppManager,
-      aclSnippet: 'pm.multi-app-manager.applications',
+      aclSnippet: 'pm.multi-app.applications',
     });
 
     const blockInitializers = this.app.schemaInitializerManager.get('page:addBlock');

--- a/packages/module-ui-schema/src/server/server.ts
+++ b/packages/module-ui-schema/src/server/server.ts
@@ -27,7 +27,7 @@ export class ModuleUiSchema extends Plugin {
     this.registerRepository();
 
     this.app.acl.registerSnippet({
-      name: `pm.${this.name}.block-templates`,
+      name: `pm.ui-schema-storage.block-templates`,
       actions: ['uiSchemaTemplates:*'],
     });
 

--- a/packages/module-web/src/server/server.ts
+++ b/packages/module-web/src/server/server.ts
@@ -73,8 +73,6 @@ export class ModuleWeb extends Plugin {
     this.app.localeManager.setLocaleFn('cron', async (lang) => getCronLocale(lang));
     this.app.acl.allow('app', 'getLang');
     this.app.acl.allow('app', 'getInfo');
-    // TODO: 此处应该删掉,但是不确定其他地方是否有用到
-    this.app.acl.allow('plugins', '*', 'public');
     this.app.acl.registerSnippet({
       name: 'app',
       actions: ['app:restart', 'app:refresh', 'app:clearCache'],

--- a/packages/module-worker-thread/src/server/plugin.ts
+++ b/packages/module-worker-thread/src/server/plugin.ts
@@ -1,6 +1,7 @@
 import { isMainThread } from 'worker_threads';
 import { InjectedPlugin, Plugin } from '@tachybase/server';
 
+import { NAMESPACE } from '../constants';
 import { WORKER_COUNT, WORKER_COUNT_SUB } from './constants';
 import { WorkerManager } from './workerManager';
 import { WorkerWebController } from './workerWebController';
@@ -47,7 +48,7 @@ export class ModuleWorkerThreadServer extends Plugin {
 
     // 严格控制管理员才能设置
     this.app.acl.registerSnippet({
-      name: `pm.system-services.${this.name}`,
+      name: `pm.system-services.${NAMESPACE}`,
       actions: ['worker_thread:*'],
     });
   }

--- a/packages/plugin-block-map/src/server/plugin.ts
+++ b/packages/plugin-block-map/src/server/plugin.ts
@@ -37,7 +37,7 @@ export class MapPlugin extends Plugin {
     });
 
     this.app.acl.registerSnippet({
-      name: `pm.${this.name}.configuration`,
+      name: `pm.map.configuration`,
       actions: ['map-configuration:set'],
     });
 

--- a/packages/plugin-data-source-common/src/server/plugin.ts
+++ b/packages/plugin-data-source-common/src/server/plugin.ts
@@ -28,7 +28,7 @@ export class PluginExternalDataSourceServer extends Plugin {
     // 通过菜单权限数据源管理的管理员能够运行测试,crud任意操作
     this.app.acl.registerSnippet({
       name: 'pm.database-connections.manager',
-      actions: ['dataSources.*:*'],
+      actions: ['dataSources.*:*', 'dataSources:*'],
     });
   }
 

--- a/packages/plugin-devtools/src/client/index.tsx
+++ b/packages/plugin-devtools/src/client/index.tsx
@@ -57,17 +57,19 @@ export class PluginDevToolClient extends Plugin {
       title: lang('API Doc'),
       icon: 'BookOutlined',
       Component: SCDocumentation,
-      aclSnippet: 'pm.api-doc.documentation',
+      aclSnippet: 'pm.devtools.documentation',
     });
     this.app.systemSettingsManager.add('devtools.env', {
       title: lang('Environment'),
       icon: 'CodeOutlined',
       Component: ENVToolPane,
+      aclSnippet: 'pm.devtools.environment',
     });
     this.app.systemSettingsManager.add('devtools.middlewaresorder', {
       title: lang('Middlewares order'),
       icon: 'CodeOutlined',
       Component: MiddlewareToolPane,
+      aclSnippet: 'pm.devtools.middlewares',
     });
     this.app.systemSettingsManager.add('devtools.clientrouter', {
       title: lang('Client router'),

--- a/packages/plugin-devtools/src/server/plugin.ts
+++ b/packages/plugin-devtools/src/server/plugin.ts
@@ -54,7 +54,7 @@ export class PluginDevToolServer extends Plugin {
       actions: ['middlewares:*'],
     });
     this.app.acl.registerSnippet({
-      name: `pm.${this.name}.enviroment`,
+      name: `pm.${this.name}.environment`,
       actions: ['enviroment:*'],
     });
   }

--- a/packages/plugin-i18n-editor/src/server/plugin.ts
+++ b/packages/plugin-i18n-editor/src/server/plugin.ts
@@ -59,7 +59,7 @@ export class LocalizationManagementPlugin extends Plugin {
     });
 
     this.app.acl.registerSnippet({
-      name: `pm.${this.name}.localization`,
+      name: `pm.localization-management.localization`,
       actions: ['localization:*', 'localizationTexts:*', 'localizationTranslations:*'],
     });
 

--- a/packages/plugin-log-viewer/src/client/index.tsx
+++ b/packages/plugin-log-viewer/src/client/index.tsx
@@ -9,6 +9,7 @@ export class PluginLogViewer extends Plugin {
       title: lang('Log Viewer'),
       icon: 'FileTextOutlined',
       Component: LogsDownloader,
+      aclSnippet: 'pm.system-services.log-viewer',
     });
   }
 }

--- a/packages/plugin-log-viewer/src/server/plugin.ts
+++ b/packages/plugin-log-viewer/src/server/plugin.ts
@@ -10,7 +10,7 @@ export class PluginLogViewerServer extends Plugin {
   async load() {
     this.app.resource(logger);
     this.app.acl.registerSnippet({
-      name: `pm.${this.name}.logger`,
+      name: 'pm.system-services.log-viewer',
       actions: ['logger:*'],
     });
   }

--- a/packages/plugin-otp/src/server/Plugin.ts
+++ b/packages/plugin-otp/src/server/Plugin.ts
@@ -148,7 +148,7 @@ export default class PluginOtp extends Plugin {
 
     app.acl.allow('verifications', 'create', 'public');
     this.app.acl.registerSnippet({
-      name: `pm.${this.name}.providers`,
+      name: `pm.verification.providers`,
       actions: ['verifications_providers:*'],
     });
   }

--- a/packages/plugin-prototype-simple-cms/src/client/index.tsx
+++ b/packages/plugin-prototype-simple-cms/src/client/index.tsx
@@ -18,6 +18,7 @@ export class PluginHomePageClient extends Plugin {
       title: tval('Homepage config'),
       icon: 'HomeOutlined',
       Component: HomePageConfiguration,
+      aclSnippet: 'pm.system-services.homepage',
     });
   }
 }

--- a/packages/plugin-prototype-simple-cms/src/server/plugin.ts
+++ b/packages/plugin-prototype-simple-cms/src/server/plugin.ts
@@ -12,6 +12,10 @@ export class PluginHomePageServer extends Plugin {
 
   async install() {
     await Container.get(HomePageService).install();
+    this.app.acl.registerSnippet({
+      name: `pm.system-services.homepage`,
+      actions: ['home_page_presentations:*'],
+    });
   }
 
   async afterEnable() {}

--- a/packages/plugin-theme-editor/src/server/plugin.ts
+++ b/packages/plugin-theme-editor/src/server/plugin.ts
@@ -23,7 +23,7 @@ export class ThemeEditorPlugin extends Plugin {
     this.app.acl.allow('themeConfig', 'list', 'public');
 
     this.app.acl.registerSnippet({
-      name: `pm.${this.name}.themeConfig`,
+      name: `pm.theme-editor.themes`,
       actions: ['themeConfig:*'],
     });
   }


### PR DESCRIPTION
之前修改权限的时候
权限角色管理数据表权限无法配置
<img width="1158" alt="image" src="https://github.com/user-attachments/assets/8f7113db-383b-48fa-9dc9-6cc9082cfe1f" />

而且之前前端管理后台的配置权限也有一部分不一致
