### PR TITLE
fix: env secrets use error

### DIFF
--- a/packages/module-file/src/client/schemas/storage.ts
+++ b/packages/module-file/src/client/schemas/storage.ts
@@ -12,7 +12,7 @@ export const collectionFileManager = {
       uiSchema: {
         title: '{{t("Title")}}',
         type: 'string',
-        'x-component': 'TextAreaWithGlobalScope',
+        'x-component': 'Input',
         required: true,
       } as ISchema,
     },

--- a/packages/module-file/src/client/schemas/storageTypes/ali-oss.ts
+++ b/packages/module-file/src/client/schemas/storageTypes/ali-oss.ts
@@ -44,7 +44,6 @@ export default {
           type: 'string',
           'x-decorator': 'FormItem',
           'x-component': 'TextAreaWithGlobalScope',
-          'x-component-props': { password: true },
           required: true,
         },
         bucket: {

--- a/packages/module-file/src/client/schemas/storageTypes/s3.ts
+++ b/packages/module-file/src/client/schemas/storageTypes/s3.ts
@@ -44,7 +44,6 @@ export default {
           type: 'string',
           'x-decorator': 'FormItem',
           'x-component': 'TextAreaWithGlobalScope',
-          'x-component-props': { password: true },
           required: true,
         },
         bucket: {

--- a/packages/module-file/src/client/schemas/storageTypes/tx-cos.ts
+++ b/packages/module-file/src/client/schemas/storageTypes/tx-cos.ts
@@ -44,7 +44,6 @@ export default {
           type: 'string',
           'x-decorator': 'FormItem',
           'x-component': 'TextAreaWithGlobalScope',
-          'x-component-props': { password: true },
           required: true,
         },
         Bucket: {

--- a/packages/plugin-data-source-common/src/client/features/rest-api/form-data-source/DataSourceSettingsForm.schema.ts
+++ b/packages/plugin-data-source-common/src/client/features/rest-api/form-data-source/DataSourceSettingsForm.schema.ts
@@ -74,10 +74,7 @@ export const schemaDataSourceSettingsForm = {
                   value: {
                     type: 'string',
                     'x-decorator': 'FormItem',
-                    'x-component': 'Input',
-                    'x-component-props': {
-                      useTypedConstant: true,
-                    },
+                    'x-component': 'TextAreaWithGlobalScope',
                   },
                   remove: {
                     type: 'void',

--- a/packages/plugin-data-source-common/src/server/http/plugin.ts
+++ b/packages/plugin-data-source-common/src/server/http/plugin.ts
@@ -25,6 +25,7 @@ export class PluginHttpDatasource extends Plugin {
             parseField: inferFields,
             runAsDebug: debug,
             debugVars,
+            environment: ctx.app.environment,
           });
           await next();
         },


### PR DESCRIPTION
文件管理里title不用变量和密钥但是secretKey需要
httpCollection里面 header支持变量和密钥

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - **UI Enhancements:** The title field now uses a single-line input instead of a multi-line text area. In addition, header values in data source forms are now entered via a multi-line text area, and secret fields have been adjusted to remove password masking.
  - **HTTP Request Improvements:** HTTP actions now support dynamic header rendering based on the current environment context, offering better integration and configuration flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->