### PR TITLE
fix: $dateBetween error

### DIFF
--- a/packages/client/src/filter-provider/utils.ts
+++ b/packages/client/src/filter-provider/utils.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { Schema, useFieldSchema } from '@tachybase/schema';
-import { flatten, getValuesByPath } from '@tachybase/utils/client';
+import { dayjs, flatten, getValuesByPath } from '@tachybase/utils/client';
 
 import _ from 'lodash';
 
@@ -159,6 +159,17 @@ export const transformToFilter = (
                 $isFalsy: true,
               },
             };
+          }
+        } else if (operators[key] === '$dateBetween') {
+          if (Array.isArray(value)) {
+            for (const index in value) {
+              if (!value[index]) {
+                continue;
+              }
+              if (typeof value[index] !== 'string' && !(value[index] instanceof Date)) {
+                value[index] = dayjs(value[index]).toISOString();
+              }
+            }
           }
         }
         return {


### PR DESCRIPTION
时间介于如果设置了默认值
因为DateRange时间段选择起点击重置后再点击筛选会在接口参数接口使用了Moment类型
这里filter应该转成string

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced date range filtering to ensure that various date inputs are accurately converted into a standardized format, providing a more reliable filtering experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->