### PR TITLE
fix: backup individual file path

### DIFF
--- a/packages/module-backup/src/server/resourcers/backup-files.ts
+++ b/packages/module-backup/src/server/resourcers/backup-files.ts
@@ -35,6 +35,7 @@ export default {
       const dumper = new Dumper(ctx.app);
       const backupFiles = await dumper.allBackUpFilePaths({
         includeInProgress: true,
+        appName: ctx.app.name,
       });
 
       // handle pagination
@@ -60,7 +61,7 @@ export default {
     async get(ctx, next) {
       const { filterByTk } = ctx.action.params;
       const dumper = new Dumper(ctx.app);
-      const filePath = dumper.backUpFilePath(filterByTk);
+      const filePath = dumper.backUpFilePath(filterByTk, ctx.app.name);
 
       async function sendError(message, status = 404) {
         ctx.body = { status: 'error', message };
@@ -150,7 +151,7 @@ export default {
       const { filterByTk } = ctx.action.params;
       const dumper = new Dumper(ctx.app);
 
-      const filePath = dumper.backUpFilePath(filterByTk);
+      const filePath = dumper.backUpFilePath(filterByTk, ctx.app.name);
 
       const fileState = await Dumper.getFileStatus(filePath);
 
@@ -181,7 +182,7 @@ export default {
 
         if (filterByTk) {
           const dumper = new Dumper(ctx.app);
-          return dumper.backUpFilePath(filterByTk);
+          return dumper.backUpFilePath(filterByTk, ctx.app.name);
         }
       })();
 
@@ -203,7 +204,7 @@ export default {
     async destroy(ctx, next) {
       const { filterByTk } = ctx.action.params;
       const dumper = new Dumper(ctx.app);
-      const filePath = dumper.backUpFilePath(filterByTk);
+      const filePath = dumper.backUpFilePath(filterByTk, ctx.app.name);
 
       await fsPromises.unlink(filePath);
 

--- a/packages/module-backup/src/server/server.ts
+++ b/packages/module-backup/src/server/server.ts
@@ -21,6 +21,7 @@ export default class PluginBackupRestoreServer extends Plugin {
 
     return dumper.runDumpTask({
       groups: new Set(data.dataTypes) as Set<DumpRulesGroupType>,
+      appName: this.app.name,
     });
   }
 }


### PR DESCRIPTION
备份文件,子应用和主应用应该隔离开

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional application identifier for backup operations, allowing backups to be stored in distinct directories based on the app context.
  - Enhanced backup file management across various operations by incorporating the application context, improving organization and reducing potential conflicts.
  - Updated backup task initialization to consistently include the current application's information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->