### PR TITLE
fix: multi-app template must be not running

### DIFF
--- a/packages/module-multi-app/src/server/actions/apps.ts
+++ b/packages/module-multi-app/src/server/actions/apps.ts
@@ -68,10 +68,10 @@ export async function create(ctx: Context, next: Next) {
     if (matchedApp.length === 0) {
       ctx.throw(400, ctx.t('Template not exists', { ns: NAMESPACE }));
     }
-    const appStatus = AppSupervisor.getInstance().getAppStatus(tmpl, 'initialized');
-    if (appStatus !== 'stopped' && appStatus !== 'initialized') {
-      ctx.throw(400, ctx.t('Template is in use', { ns: NAMESPACE }));
-    }
+    // const appStatus = AppSupervisor.getInstance().getAppStatus(tmpl, 'initialized');
+    // if (appStatus !== 'stopped' && appStatus !== 'initialized') {
+    //   ctx.throw(400, ctx.t('Template is in use', { ns: NAMESPACE }));
+    // }
   }
   const app = await ctx.db.getRepository('applications').create({
     values: {


### PR DESCRIPTION
为了保证数据的可用性,使用模板的对象不能是正在运行的
可能会导致正在运行的对象短暂的数据库断联