### PR TITLE
fix: backup subapp worker appName error

### DIFF
--- a/packages/module-backup/src/server/resourcers/backup-files.ts
+++ b/packages/module-backup/src/server/resourcers/backup-files.ts
@@ -122,6 +122,7 @@ export default {
             method: 'workerCreateBackUp',
             params: {
               dataTypes: data.dataTypes,
+              appName: ctx.app.name,
             },
             // 目前限制方法并发为1
             concurrency: 1,

--- a/packages/module-backup/src/server/resourcers/backup-files.ts
+++ b/packages/module-backup/src/server/resourcers/backup-files.ts
@@ -132,7 +132,10 @@ export default {
         }
       } else {
         const plugin = app.pm.get(PluginBackupRestoreServer) as PluginBackupRestoreServer;
-        taskId = await plugin.workerCreateBackUp(data);
+        taskId = await plugin.workerCreateBackUp({
+          dataTypes: data.dataTypes,
+          appName: ctx.app.name,
+        });
       }
 
       ctx.body = {

--- a/packages/module-backup/src/server/server.ts
+++ b/packages/module-backup/src/server/server.ts
@@ -16,12 +16,12 @@ export default class PluginBackupRestoreServer extends Plugin {
     this.app.resourcer.define(backupFilesResourcer);
   }
 
-  async workerCreateBackUp(data: { dataTypes: string[] }) {
+  async workerCreateBackUp(data: { dataTypes: string[]; appName: string }) {
     const dumper = new Dumper(this.app);
 
     return dumper.runDumpTask({
       groups: new Set(data.dataTypes) as Set<DumpRulesGroupType>,
-      appName: this.app.name,
+      appName: data.appName,
     });
   }
 }


### PR DESCRIPTION
子应用如果用工作线程去备份就会找不到文件
因为文件地址有问题,用的工作线程的appName的缘故

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced backup operations now include explicit application identification, ensuring backups accurately reflect the correct application context.
	- The backup creation process now requires an application name alongside the data types, improving clarity in backup requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->