### PR TITLE
fix: sub app loop

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -102,3 +102,6 @@ WORKER_COUNT_MAX_SUB=1
 
 # 开发环境测试locale 强制使用 cache
 #FORCE_LOCALE_CACHE=1
+
+# 禁止子应用装载的插件，多个用逗号分隔
+FORBID_SUB_APP_PLUGINS=multi-app,manual-notification,multi-app-share-collection

--- a/packages/module-multi-app/src/client/system/AppManager.tsx
+++ b/packages/module-multi-app/src/client/system/AppManager.tsx
@@ -102,7 +102,7 @@ const GlobalNotificationHandler = (props) => {
         key: NOTIFICATION_CLIENT_KEY,
         message: message.message,
       });
-    } else if (message.status !== 'running' && message.status === 'initialing') {
+    } else if (message.status !== 'commanding' && message.status !== 'initializing') {
       notification.destroy(NOTIFICATION_CLIENT_KEY);
     }
     // 当前records没有则不刷新

--- a/packages/preset-tachybase/src/server/index.ts
+++ b/packages/preset-tachybase/src/server/index.ts
@@ -252,8 +252,8 @@ export class PresetTachyBase extends Plugin {
     const existPlugins = await repository.find();
     const existPluginNames = existPlugins.map((item) => item.name);
     const plugins = (await this.allPlugins()).filter((item) => !existPluginNames.includes(item.name));
-    const afterFilterPlugins = this.filterForbidSubAppPlugin(plugins);
-    await repository.create({ values: afterFilterPlugins });
+    this.filterForbidSubAppPlugin(plugins);
+    await repository.create({ values: plugins });
   }
 
   async install() {
@@ -285,7 +285,11 @@ export class PresetTachyBase extends Plugin {
     }
     const forbidPlugins = this.getForbidSubAppPlugin();
     const repository = this.pm.repository;
-    await repository.destroy({
+    await repository.update({
+      values: {
+        subView: false,
+        enabled: false,
+      },
       filter: {
         name: {
           $in: forbidPlugins,
@@ -299,7 +303,12 @@ export class PresetTachyBase extends Plugin {
       return;
     }
     const forbidPlugins = this.getForbidSubAppPlugin();
-    return plugins.filter((plugin) => !forbidPlugins.includes(plugin.name));
+    plugins.forEach((plugin) => {
+      if (forbidPlugins.includes(plugin.name)) {
+        plugin.subView = false;
+        plugin.enabled = false;
+      }
+    });
   }
 }
 

--- a/packages/preset-tachybase/src/server/index.ts
+++ b/packages/preset-tachybase/src/server/index.ts
@@ -252,7 +252,8 @@ export class PresetTachyBase extends Plugin {
     const existPlugins = await repository.find();
     const existPluginNames = existPlugins.map((item) => item.name);
     const plugins = (await this.allPlugins()).filter((item) => !existPluginNames.includes(item.name));
-    await repository.create({ values: plugins });
+    const afterFilterPlugins = this.filterForbidSubAppPlugin(plugins);
+    await repository.create({ values: afterFilterPlugins });
   }
 
   async install() {
@@ -266,7 +267,39 @@ export class PresetTachyBase extends Plugin {
 
   async upgrade() {
     this.log.info('update built-in plugins');
+    await this.forbidSubAppPlugin();
     await this.updateOrCreatePlugins();
+  }
+
+  getForbidSubAppPlugin() {
+    if (this.app.name === 'main') {
+      return [];
+    }
+    const { FORBID_SUB_APP_PLUGINS } = process.env;
+    return FORBID_SUB_APP_PLUGINS ? FORBID_SUB_APP_PLUGINS.split(',') : [];
+  }
+  // 从环境变量读取禁止子应用装载的插件
+  async forbidSubAppPlugin() {
+    if (this.app.name === 'main') {
+      return;
+    }
+    const forbidPlugins = this.getForbidSubAppPlugin();
+    const repository = this.pm.repository;
+    await repository.destroy({
+      filter: {
+        name: {
+          $in: forbidPlugins,
+        },
+      },
+    });
+  }
+
+  async filterForbidSubAppPlugin(plugins: any[]) {
+    if (this.app.name === 'main') {
+      return;
+    }
+    const forbidPlugins = this.getForbidSubAppPlugin();
+    return plugins.filter((plugin) => !forbidPlugins.includes(plugin.name));
   }
 }
 

--- a/packages/server/src/plugin-manager/options/collection.ts
+++ b/packages/server/src/plugin-manager/options/collection.ts
@@ -13,5 +13,6 @@ export default defineCollection({
     { type: 'boolean', name: 'installed' },
     { type: 'boolean', name: 'builtIn' },
     { type: 'json', name: 'options' },
+    { type: 'boolean', name: 'subView', defaultValue: true },
   ],
 });

--- a/packages/server/src/plugin-manager/options/resource.ts
+++ b/packages/server/src/plugin-manager/options/resource.ts
@@ -116,7 +116,11 @@ export default {
     async list(ctx, next) {
       const locale = ctx.getCurrentLocale();
       const pm = ctx.app.pm as PluginManager;
-      ctx.body = await pm.list({ locale, isPreset: false });
+      if (ctx.app.name === 'main') {
+        ctx.body = await pm.list({ locale, isPreset: false });
+      } else {
+        ctx.body = await pm.list({ locale, isPreset: false, subView: true });
+      }
       await next();
     },
     async listEnabled(ctx, next) {
@@ -125,6 +129,7 @@ export default {
       const items = await pm.find({
         filter: {
           enabled: true,
+          subView: true,
         },
       });
       ctx.body = items

--- a/packages/server/src/plugin-manager/plugin-manager.ts
+++ b/packages/server/src/plugin-manager/plugin-manager.ts
@@ -328,7 +328,10 @@ export class PluginManager {
 
     this.pluginInstances.set(P, instance);
     if (options.name) {
-      this.pluginAliases.set(options.name, instance);
+      // 禁止子应用显示的插件
+      if (this.app.name === 'main' || options.subView) {
+        this.pluginAliases.set(options.name, instance);
+      }
     }
     if (insert && options.name) {
       await this.repository.updateOrCreate({


### PR DESCRIPTION
子应用嵌套子应用会导致start出现bug,现在可以关闭子应用哪些插件被删掉

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a configuration option to restrict the loading of certain plugins in sub-applications.
	- Enhanced plugin management so that forbidden plugins are automatically filtered out during updates.
	- Added a new boolean field `subView` to the collection schema to improve collection management.
- **Bug Fixes**
	- Adjusted notification handling to ensure outdated notifications are cleared more reliably.
- **Improvements**
	- Modified the logic for listing plugins based on the application context to enhance retrieval accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->