### PR TITLE
fix: can change primary key or unique in http collection

### DIFF
--- a/packages/client/src/collection-manager/interfaces/properties/index.ts
+++ b/packages/client/src/collection-manager/interfaces/properties/index.ts
@@ -37,7 +37,7 @@ export const unique = {
   'x-content': '{{t("Unique")}}',
   'x-decorator': 'FormItem',
   'x-component': 'Checkbox',
-  'x-disabled': '{{ !createMainOnly }}',
+  // 'x-disabled': '{{ !createMainOnly }}',
   'x-reactions': [
     {
       dependencies: ['primaryKey'],
@@ -55,7 +55,7 @@ export const primaryKey = {
   'x-content': '{{t("Primary")}}',
   'x-decorator': 'FormItem',
   'x-component': 'Checkbox',
-  'x-disabled': '{{ !createMainOnly }}',
+  // 'x-disabled': '{{ !createMainOnly }}',
   'x-reactions': [
     {
       dependencies: ['unique'],


### PR DESCRIPTION
允许在http等其他数据源设置主键和不允许重复

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the behavior of specific configuration checkboxes so they are always enabled, providing a more consistent and accessible interaction experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->