### PR TITLE
feat: sms auth agree

### DIFF
--- a/packages/plugin-auth-sms/src/client/Options.tsx
+++ b/packages/plugin-auth-sms/src/client/Options.tsx
@@ -23,6 +23,18 @@ export const Options = () => {
                     title: '{{t("Sign up automatically when the user does not exist")}}',
                     'x-component': 'Checkbox',
                   },
+                  agreeMust: {
+                    'x-decorator': 'FormItem',
+                    type: 'boolean',
+                    title: '{{t("Must agree to the agreement")}}',
+                    'x-component': 'Checkbox',
+                  },
+                  agreeCode: {
+                    'x-decorator': 'FormItem',
+                    type: 'string',
+                    title: '{{t("Agree to the agreement text (html supported)")}}',
+                    'x-component': 'Input.TextArea',
+                  },
                 },
               },
             },

--- a/packages/plugin-auth-sms/src/client/locale/index.ts
+++ b/packages/plugin-auth-sms/src/client/locale/index.ts
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next';
 
-export const NAMESPACE = 'sms-auth';
+export const NAMESPACE = 'auth-sms';
 
 export function useAuthTranslation() {
   return useTranslation(NAMESPACE);

--- a/packages/plugin-auth-sms/src/locale/en-US.json
+++ b/packages/plugin-auth-sms/src/locale/en-US.json
@@ -1,4 +1,6 @@
 {
+  "Agree to the agreement text (html supported)": "Agree to the agreement text (html supported)",
+  "Must agree to the agreement": "Must agree to the agreement",
   "Sign in via SMS": "Sign in via SMS",
   "Sign up automatically when the user does not exist": "Sign up automatically when the user does not exist",
   "User will be registered automatically if not exists.": "User will be registered automatically if not exists."

--- a/packages/plugin-auth-sms/src/locale/zh-CN.json
+++ b/packages/plugin-auth-sms/src/locale/zh-CN.json
@@ -1,4 +1,6 @@
 {
+  "Agree to the agreement text (html supported)": "同意协议文本(支持html)",
+  "Must agree to the agreement": "必须同意协议",
   "Sign in via SMS": "短信登录",
   "Sign up automatically when the user does not exist": "用户不存在时自动注册",
   "User will be registered automatically if not exists.": "用户不存在时将自动注册。"


### PR DESCRIPTION
短信登录注册的时候可以必须同意协议
协议可以用html写入
<img width="871" alt="image" src="https://github.com/user-attachments/assets/49a1a9c8-44a0-4aa4-a2e7-951a0adbbf89" />
<img width="721" alt="image" src="https://github.com/user-attachments/assets/4f9eb2dd-afb2-477b-9fea-51a6bf5f5d0d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable agreement checkbox and custom agreement text to the SMS authentication sign-in form. Users may be required to agree to terms before signing in, with support for HTML-formatted agreement text.

- **Localization**
  - Added English and Chinese translations for the new agreement-related fields.

- **Style**
  - Updated label text and namespace for improved clarity in localization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->