### PR TITLE
fix: http field int allow float type

### DIFF
--- a/packages/plugin-data-source-common/src/server/http/services/http-collection.ts
+++ b/packages/plugin-data-source-common/src/server/http/services/http-collection.ts
@@ -89,10 +89,7 @@ function rawTypeToFieldType(rawType, exampleValue) {
     },
     number: () => {
       if (Number.isInteger(exampleValue)) {
-        if (dayjs(exampleValue).isValid()) {
-          return ['integer', 'bigInt'];
-        }
-        return 'integer';
+        return ['integer', 'float', 'date', 'bigInt'];
       }
       return 'float';
     },


### PR DESCRIPTION
允许http数据源 int类型 数据表类型为float

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified and broadened the logic for inferring data types from numeric values, now including more possible types for integer values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->