### PR TITLE
fix: 钉钉插件修复

### DIFF
--- a/packages/plugin-auth-dingtalk/src/client/components.tsx
+++ b/packages/plugin-auth-dingtalk/src/client/components.tsx
@@ -50,18 +50,22 @@ export const AdminSettingsForm = () => {
                   required: true,
                   title: '{{t("Client Secret")}}',
                 },
+                redirectUrl: {
+                  'x-decorator': 'FormItem',
+                  'x-component': 'Input',
+                  type: 'string',
+                  required: true,
+                  title: '{{t("Redirect URL")}}',
+                  'x-component-props': {
+                    disabled: false,
+                  },
+                  default: redirectUrl,
+                },
               },
             },
           },
         }}
       />
-      <div>
-        <Typography.Title level={5} style={{ fontSize: '14px' }}>
-          {t('Redirect URL')}
-          <span style={{ marginLeft: '2px' }}>:</span>
-        </Typography.Title>
-        <Input value={redirectUrl} disabled={true} addonBefore={<CopyOutlined onClick={() => onCopy(redirectUrl)} />} />
-      </div>
     </div>
   );
 };

--- a/packages/plugin-auth-dingtalk/src/server/dingtalk-auth.ts
+++ b/packages/plugin-auth-dingtalk/src/server/dingtalk-auth.ts
@@ -19,7 +19,7 @@ export class DingtalkAuth extends BaseAuth {
     }
     const dingtalkClient = new DingtalkClient({
       clientId: this.options?.dingtalk?.clientId,
-      clientSecret: this.options?.clientSecret,
+      clientSecret: this.options?.dingtalk?.clientSecret,
       ctx: this.ctx,
     });
     const accessToken = await dingtalkClient.getAccessToken(authCode);
@@ -61,7 +61,7 @@ export class DingtalkAuth extends BaseAuth {
     const clientId = this.options?.dingtalk?.clientId;
     const app = this.ctx.app.name;
     const redirectUrl = encodeURIComponent(
-      `${this.ctx.protocol}://${this.ctx.host}${process.env.API_BASE_PATH}dingtalk:redirect`,
+      this.options?.dingtalk?.redirectUrl || '',
     );
     // TODO: 如果后续有登录后绑定的场景，服务端需要校验 state
     const state = encodeURIComponent(`redirect=${redirect}&app=${app}&name=${this.ctx.headers['x-authenticator']}`);


### PR DESCRIPTION
## 存在问题
1. 钉钉密钥信息clientSecret取值少取了一层
2. 登录界面点击钉钉登录认证按钮时，获取到的host:port为server端口，与配置钉钉认证界面时前端获取不一样，导致回调需要回调到服务端端口，而生产环境部署时不应暴露服务端端口

## 处理方法
1. 钉钉认证信息配置取值错误 
2. 钉钉认证回调重定向URL改为client生成后存储到配置中，避免后端服务自动获取的URL与前端不一致

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The "Redirect URL" field in the DingTalk configuration is now an editable input, allowing users to modify it directly within the settings form.

- **Bug Fixes**
  - Corrected the retrieval of the DingTalk client secret and redirect URL to ensure accurate configuration and improved reliability during authentication setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->