### PR TITLE
fix: department server client acl not match

### DIFF
--- a/packages/plugin-department/src/server/plugin.ts
+++ b/packages/plugin-department/src/server/plugin.ts
@@ -49,7 +49,7 @@ export class PluginDepartmentServer extends Plugin {
     });
     this.app.acl.allow('users', ['setMainDepartment', 'listExcludeDept'], 'loggedIn');
     this.app.acl.registerSnippet({
-      name: `pm.${this.name}.*`,
+      name: `pm.${this.name}`,
       actions: [
         'departments:*',
         'roles:list',


### PR DESCRIPTION
部门权限 前后端不一致

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated internal handling of permission snippet names for improved consistency. No changes to user-facing actions or permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->