### PR TITLE
fix: hide extra when form item description empty

### DIFF
--- a/packages/client/src/schema-component/antd/form-item/FormItem.tsx
+++ b/packages/client/src/schema-component/antd/form-item/FormItem.tsx
@@ -67,15 +67,18 @@ export const FormItem = (props: any) => {
   const showTitle = schema['x-decorator-props']?.showTitle ?? true;
 
   const extra = useMemo(() => {
-    return typeof field.description === 'string' ? (
-      <div
-        dangerouslySetInnerHTML={{
-          __html: HTMLEncode(field.description).split('\n').join('<br/>'),
-        }}
-      />
-    ) : (
-      field.description
-    );
+    if (typeof field.description === 'string') {
+      const desc = field.description.trim();
+      if (!desc) return undefined;
+      return (
+        <div
+          dangerouslySetInnerHTML={{
+            __html: HTMLEncode(desc).split('\n').join('<br/>'),
+          }}
+        />
+      );
+    }
+    return field.description ?? undefined;
   }, [field.description]);
   const className = useMemo(() => {
     return cx(


### PR DESCRIPTION
编辑描述后，清空描述依旧会有一个占位

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of form field descriptions to prevent empty description boxes from appearing when no description is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->