### PR TITLE
feat: init with project name

### DIFF
--- a/apps/cli/src/commands/init.ts
+++ b/apps/cli/src/commands/init.ts
@@ -167,7 +167,7 @@ export default (cli: Command) => {
         .map((s) => s.trim())
         .filter(Boolean);
     })
-    .argument('<name>')
+    .argument('<name>', 'project name', 'my-app')
     .allowUnknownOption()
     .action(async (name: string, options) => {
       if (fs.existsSync(name)) {

--- a/apps/cli/src/commands/init.ts
+++ b/apps/cli/src/commands/init.ts
@@ -54,8 +54,8 @@ const plugins = [
   'manual-notification',
 ];
 
-function initEnv() {
-  const envPath = path.resolve(process.cwd(), '.env');
+function initEnv(name: string) {
+  const envPath = path.resolve(process.cwd(), name, '.env');
 
   if (!fs.existsSync(envPath)) {
     const content = `
@@ -167,11 +167,17 @@ export default (cli: Command) => {
         .map((s) => s.trim())
         .filter(Boolean);
     })
+    .argument('<name>')
     .allowUnknownOption()
-    .action(async (options) => {
-      initEnv();
+    .action(async (name: string, options) => {
+      if (fs.existsSync(name)) {
+        console.log(`project folder ${name} already exists, exit now.`);
+        return;
+      }
+      fs.mkdirSync(name);
+      initEnv(name);
 
-      const prefix = 'plugins/node_modules';
+      const prefix = `${name}/plugins/node_modules`;
       // 安装前端代码
       console.log('🚀 ~ start download ~ front end files');
       const spinner = yoctoSpinner({ text: `Loading @tachybase/app-web` }).start();

--- a/apps/cli/src/commands/init.ts
+++ b/apps/cli/src/commands/init.ts
@@ -167,7 +167,7 @@ export default (cli: Command) => {
         .map((s) => s.trim())
         .filter(Boolean);
     })
-    .argument('<name>', 'project name', 'my-app')
+    .argument('[name]', 'project name', 'my-app')
     .allowUnknownOption()
     .action(async (name: string, options) => {
       if (fs.existsSync(name)) {

--- a/apps/engine/src/index.ts
+++ b/apps/engine/src/index.ts
@@ -3,6 +3,7 @@ import './intercept';
 import fs from 'node:fs';
 import path, { resolve } from 'node:path';
 import { performance } from 'node:perf_hooks';
+import process from 'node:process';
 import { Gateway } from '@tachybase/server';
 
 import { config } from 'dotenv';
@@ -23,6 +24,12 @@ function parseEnv(name: string) {
   }
 }
 
+// 猜测所在位置
+let guessPath;
+if (fs.existsSync(path.join(process.cwd(), 'plugins/node_modules'))) {
+  guessPath = path.join(process.cwd(), 'plugins/node_modules');
+}
+
 function initEnv() {
   const env = {
     APP_ENV: 'development',
@@ -40,7 +47,7 @@ function initEnv() {
     MFSU_AD: 'none',
     WS_PATH: '/ws',
     SOCKET_PATH: 'storage/gateway.sock',
-    NODE_MODULES_PATH: resolve(process.cwd(), 'node_modules'),
+    NODE_MODULES_PATH: guessPath ? resolve(process.cwd(), 'node_modules') : guessPath,
     PM2_HOME: resolve(process.cwd(), './storage/.pm2'),
     PLUGIN_PACKAGE_PREFIX: '@tachybase/plugin-,@tachybase/module-',
     SERVER_TSCONFIG_PATH: './tsconfig.server.json',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The CLI now accepts an optional project name when initializing, creating a dedicated project directory with all generated files and downloads contained within it.
  - Initialization checks for existing project directories and exits early with a message if the directory already exists.

- **Bug Fixes**
  - Improved environment variable handling for module paths, setting them conditionally based on the presence of a plugins directory to enhance dependency resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->