### PR TITLE
fix: event source real time refresh

### DIFF
--- a/packages/module-event-source/src/server/trigger/AppEventTrigger.ts
+++ b/packages/module-event-source/src/server/trigger/AppEventTrigger.ts
@@ -32,6 +32,10 @@ export class AppEventTrigger extends EventSourceTrigger {
     } else if (!model.enabled && this.workSet.has(model.id)) {
       this.app.db.off(model.options.eventName, this.eventMap.get(model.id));
       this.eventMap.delete(model.id);
+    } else if (this.changeWithOutType(model)) {
+      this.app.db.off(model.options.eventName, this.eventMap.get(model.id));
+      this.eventMap.delete(model.id);
+      this.load(model);
     }
   }
 

--- a/packages/module-event-source/src/server/trigger/AppEventTrigger.ts
+++ b/packages/module-event-source/src/server/trigger/AppEventTrigger.ts
@@ -33,7 +33,8 @@ export class AppEventTrigger extends EventSourceTrigger {
       this.app.db.off(model.options.eventName, this.eventMap.get(model.id));
       this.eventMap.delete(model.id);
     } else if (this.changeWithOutType(model)) {
-      this.app.db.off(model.options.eventName, this.eventMap.get(model.id));
+      const { eventName: oldEventName } = this.effectConfigMap.get(model.id).options ?? {};
+      this.app.db.off(oldEventName, this.eventMap.get(model.id));
       this.eventMap.delete(model.id);
       this.load(model);
     }

--- a/packages/module-event-source/src/server/trigger/DatabaseEventTrigger.ts
+++ b/packages/module-event-source/src/server/trigger/DatabaseEventTrigger.ts
@@ -71,7 +71,8 @@ export class DatabaseEventTrigger extends EventSourceTrigger {
       this.app.db.off(model.options.eventName, this.eventMap.get(model.id));
       this.eventMap.delete(model.id);
     } else if (this.changeWithOutType(model)) {
-      this.app.db.off(model.options.eventName, this.eventMap.get(model.id));
+      const { eventName: oldEventName } = this.effectConfigMap.get(model.id).options ?? {};
+      this.app.db.off(oldEventName, this.eventMap.get(model.id));
       this.eventMap.delete(model.id);
       this.load(model);
     }

--- a/packages/module-event-source/src/server/trigger/DatabaseEventTrigger.ts
+++ b/packages/module-event-source/src/server/trigger/DatabaseEventTrigger.ts
@@ -70,6 +70,10 @@ export class DatabaseEventTrigger extends EventSourceTrigger {
     } else if (!model.enabled && this.workSet.has(model.id)) {
       this.app.db.off(model.options.eventName, this.eventMap.get(model.id));
       this.eventMap.delete(model.id);
+    } else if (this.changeWithOutType(model)) {
+      this.app.db.off(model.options.eventName, this.eventMap.get(model.id));
+      this.eventMap.delete(model.id);
+      this.load(model);
     }
   }
 

--- a/packages/module-event-source/src/server/trigger/Trigger.ts
+++ b/packages/module-event-source/src/server/trigger/Trigger.ts
@@ -38,6 +38,17 @@ export class EventSourceTrigger implements IEventSourceTrigger {
     return this.workSet.has(model.id);
   }
 
+  // 在type未发生变化的情况下发生变化
+  changeWithOutType(model: EventSourceModel) {
+    if (model.changed('type')) {
+      return false;
+    }
+    if (!model.enabled) {
+      return false;
+    }
+    return model.changed('workflowKey') || model.changed('code') || model.changed('options');
+  }
+
   afterCreate(model: EventSourceModel) {}
 
   afterUpdate(model: EventSourceModel) {}

--- a/packages/module-event-source/src/server/webhooks/Plugin.ts
+++ b/packages/module-event-source/src/server/webhooks/Plugin.ts
@@ -147,8 +147,8 @@ export class PluginWebhook extends Plugin {
         }
         return;
       }
-      trigger.effectConfigSet(model.id, model.toJSON());
       await trigger.afterUpdate(model);
+      trigger.effectConfigSet(model.id, model.toJSON());
       this.ws.sendToConnectionsByTag('app', this.app.name, {
         type: 'maintaining',
         payload: {


### PR DESCRIPTION
当只修改事件源 数据库事件和app事件的workflowKey,事件类型,脚本这些项的时候没触发热更新
afterUpdate逻辑这里重点处理了on/off和type变更,这种小幅度变动没考虑到

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced event listener handling for app and database triggers to refresh automatically on specific model changes.
- **Bug Fixes**
  - Fixed event listeners to update correctly when changes other than enable/disable occur, improving event processing reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->