### PR TITLE
fix: engine guess wrong path

### DIFF
--- a/apps/engine/src/index.ts
+++ b/apps/engine/src/index.ts
@@ -47,7 +47,7 @@ function initEnv() {
     MFSU_AD: 'none',
     WS_PATH: '/ws',
     SOCKET_PATH: 'storage/gateway.sock',
-    NODE_MODULES_PATH: guessPath ? resolve(process.cwd(), 'node_modules') : guessPath,
+    NODE_MODULES_PATH: guessPath ?? resolve(process.cwd(), 'node_modules'),
     PM2_HOME: resolve(process.cwd(), './storage/.pm2'),
     PLUGIN_PACKAGE_PREFIX: '@tachybase/plugin-,@tachybase/module-',
     SERVER_TSCONFIG_PATH: './tsconfig.server.json',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the logic for setting the `NODE_MODULES_PATH` environment variable to improve handling of fallback values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->