### PR TITLE
fix: set PluginPresets when preset is null

### DIFF
--- a/packages/module-multi-app/src/server/server.ts
+++ b/packages/module-multi-app/src/server/server.ts
@@ -148,7 +148,7 @@ const defaultAppOptionsFactory = (appName: string, mainApp: Application, preset:
       ...rawDatabaseOptions,
       tablePrefix: '',
     },
-    plugins: preset === 'tachybase' ? [PluginPresets] : [preset],
+    plugins: preset === 'tachybase' || !preset ? [PluginPresets] : [preset],
     resourcer: {
       prefix: process.env.API_BASE_PATH,
     },


### PR DESCRIPTION
preset 为空的时候设置默认插件

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of missing or empty preset values to ensure default plugins are correctly applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->