### PR TITLE
fix: multi app stop button

### DIFF
--- a/packages/module-multi-app/src/client/system/AppManager.tsx
+++ b/packages/module-multi-app/src/client/system/AppManager.tsx
@@ -41,7 +41,7 @@ const AppVisitor = () => {
         {t('View', { ns: NAMESPACE })}
       </TrackingLink>
       {record.status !== 'running' && <a onClick={() => handleStart()}>{t('Start', { ns: NAMESPACE })}</a>}
-      {record.status === 'running' && <a onClick={() => handleStop()}>{t('Stop', { ns: NAMESPACE })}</a>}
+      {record.status !== 'stopped' && <a onClick={() => handleStop()}>{t('Stop', { ns: NAMESPACE })}</a>}
     </Space>
   );
 };

--- a/packages/module-multi-app/src/server/middlewares/inject-app-list.ts
+++ b/packages/module-multi-app/src/server/middlewares/inject-app-list.ts
@@ -10,14 +10,6 @@ export function injectAppListMiddleware() {
       for (const application of applications) {
         const appStatus = AppSupervisor.getInstance().getAppStatus(application.name, 'stopped');
         application.status = appStatus;
-        if (application.tmpl) {
-          const matchedApp = applications.find((app) => app.name === application.tmpl);
-          if (matchedApp) {
-            application.tmpl = `${matchedApp.displayName}(${application.tmpl})`;
-          } else {
-            application.tmpl = `Not Exists(${application.tmpl})`;
-          }
-        }
       }
     }
   };

--- a/packages/module-multi-app/src/server/migrations/20250618145656-fix-tmpl.ts
+++ b/packages/module-multi-app/src/server/migrations/20250618145656-fix-tmpl.ts
@@ -1,0 +1,51 @@
+import { Migration } from '@tachybase/server';
+
+/** n个嵌套的Not Exists(Not Exists(abc)) 取出中间的abc值 */
+function extractInnermost(expression) {
+  let trimmed = expression.trim();
+
+  // 正则提取 NOT EXISTS ( ... ) 的内部
+  const regex = /^NOT\s+EXISTS\s*\(\s*(.+)\s*\)$/i;
+
+  while (regex.test(trimmed)) {
+    trimmed = trimmed.match(regex)[1]; // 提取括号内部分
+  }
+
+  return trimmed;
+}
+
+export default class extends Migration {
+  on = 'afterLoad'; // 'beforeLoad' or 'afterLoad'
+  appVersion = '<1.2.7';
+
+  async up() {
+    const repo = this.db.getRepository('applications');
+    const list = await repo.find({
+      filter: {
+        tmpl: {
+          $includes: 'Not Exists',
+        },
+      },
+      raw: true,
+    });
+    if (!list.length) {
+      this.app.logger.info('multi app fix tmpl 0 rows');
+      return;
+    }
+    let count = 0;
+    for (const item of list) {
+      const originName = extractInnermost(item.tmpl);
+      if (originName === item.tmpl) {
+        continue;
+      }
+      await repo.update({
+        filterByTk: item.name,
+        values: {
+          tmpl: originName,
+        },
+      });
+      count++;
+    }
+    this.app.logger.info(`multi app fix tmpl ${count} rows`);
+  }
+}


### PR DESCRIPTION
子应用返回数据的时候对于tmpl之前会多套一个Not Exists,比较多余
子应用如果是错误状态之前没法stop再start,需要在stop有一个stop按钮

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - The "Stop" link is now displayed for any status except "stopped", improving usability in the app manager.
  - Application template information is no longer overwritten with formatted display names or "Not Exists" messages.

- **Chores**
  - Added a database migration to clean up nested "Not Exists" expressions in application templates for versions earlier than 1.2.7.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->