### PR TITLE
fix:(auth)token expire suddenly

### DIFF
--- a/packages/auth/src/base/auth.ts
+++ b/packages/auth/src/base/auth.ts
@@ -132,12 +132,13 @@ export class BaseAuth extends Auth {
 
     const tokenPolicy = await this.tokenController.getConfig();
 
-    if (signInTime && Date.now() - signInTime > tokenPolicy.sessionExpirationTime) {
-      this.ctx.throw(401, {
-        message: this.ctx.t('Your session has expired. Please sign in again.', { ns: localeNamespace }),
-        code: AuthErrorCode.EXPIRED_SESSION,
-      });
-    }
+    // 这个sessionExpirationTime比如设为7天,则会在第7天立即出现重新登录,使用体验不好
+    // if (signInTime && Date.now() - signInTime > tokenPolicy.sessionExpirationTime) {
+    //   this.ctx.throw(401, {
+    //     message: this.ctx.t('Your session has expired. Please sign in again.', { ns: localeNamespace }),
+    //     code: AuthErrorCode.EXPIRED_SESSION,
+    //   });
+    // }
 
     if (tokenStatus === 'valid' && Date.now() - iat * 1000 > tokenPolicy.tokenExpirationTime) {
       tokenStatus = 'expired';
@@ -223,6 +224,8 @@ export class BaseAuth extends Auth {
           { userId: user.id, roleName, temp, signInTime, iat: Math.floor(renewedResult.issuedTime / 1000) },
           { jwtid: renewedResult.jti, expiresIn },
         );
+        console.log('renewedResult.issuedTime', renewedResult.issuedTime);
+        console.log('expiresIn', expiresIn);
         this.ctx.res.setHeader('x-new-token', newToken);
       } catch (err) {
         this.ctx.logger.error('token renew failed', {

--- a/packages/auth/src/base/auth.ts
+++ b/packages/auth/src/base/auth.ts
@@ -224,8 +224,6 @@ export class BaseAuth extends Auth {
           { userId: user.id, roleName, temp, signInTime, iat: Math.floor(renewedResult.issuedTime / 1000) },
           { jwtid: renewedResult.jti, expiresIn },
         );
-        console.log('renewedResult.issuedTime', renewedResult.issuedTime);
-        console.log('expiresIn', expiresIn);
         this.ctx.res.setHeader('x-new-token', newToken);
       } catch (err) {
         this.ctx.logger.error('token renew failed', {


### PR DESCRIPTION
窗口期sessionExpirationTime比如设为7天,则会在第7天立即出现重新登录,使用体验不好
遂去除掉这个限制,不用管窗口期一到立即失效

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved session handling to prevent immediate forced logout when session expiration time is reached, enhancing user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->