### PR TITLE
fix: backup plugin check all & add text-copy plugin

### DIFF
--- a/packages/module-backup/src/client/Configuration.tsx
+++ b/packages/module-backup/src/client/Configuration.tsx
@@ -271,6 +271,17 @@ const NewBackup = ({ ButtonComponent = Button, refresh }) => {
   const { notification } = App.useApp();
   const [dataSource, setDataSource] = useState([]);
 
+  const indeterminate =
+    dataTypes.length > 0 && dataTypes.length < dataSource.filter((item) => item.value !== 'skipped').length;
+
+  const checkAll = dataSource.filter((item) => item.value !== 'skipped').length === dataTypes.length;
+
+  const onCheckAllChange: CheckboxProps['onChange'] = (e) => {
+    setBackupData(
+      e.target.checked ? dataSource.filter((item) => item.value !== 'skipped').map((item) => item.value) : ['required'],
+    );
+  };
+
   const showModal = async () => {
     const { data } = await apiClient.resource('backupFiles').dumpableCollections();
     setDataSource(
@@ -366,6 +377,10 @@ const NewBackup = ({ ButtonComponent = Button, refresh }) => {
             onChange={(checkValue) => setBackupData(checkValue)}
             value={dataTypes}
           />
+          <Divider />
+          <Checkbox indeterminate={indeterminate} onChange={onCheckAllChange} checked={checkAll}>
+            {t('Check all')}
+          </Checkbox>
         </div>
       </Modal>
     </>

--- a/packages/server/src/plugin-manager/plugin-presets.ts
+++ b/packages/server/src/plugin-manager/plugin-presets.ts
@@ -91,6 +91,7 @@ export class PluginPresets extends Plugin {
     ['workflow-analysis', '0.23.41', false],
     ['api-logs', '0.23.49', false],
     ['ocr-convert', '1.0.12', false],
+    ['text-copy', '1.2.11', false],
   ];
 
   get localPlugins() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a "Check all" checkbox with indeterminate state to the backup data selection, allowing users to easily select or deselect all applicable data types.
  - Introduced support for the "text-copy" plugin (version 1.2.11) in the local plugins list, initially disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->