### PR TITLE
chore: remove ts-node deps

### DIFF
--- a/apps/cli/src/commands/dev.ts
+++ b/apps/cli/src/commands/dev.ts
@@ -27,8 +27,8 @@ export default (cli: Command) => {
       }
 
       if (process.argv.includes('-h') || process.argv.includes('--help')) {
-        run('ts-node', [
-          '-P',
+        run('tsx', [
+          '--tsconfig',
           SERVER_TSCONFIG_PATH,
           '-r',
           'tsconfig-paths/register',

--- a/apps/cli/src/commands/global.ts
+++ b/apps/cli/src/commands/global.ts
@@ -7,7 +7,6 @@ export default (cli: Command) => {
   cli
     .allowUnknownOption()
     .option('-h, --help')
-    .option('--ts-node-dev')
     .action((options) => {
       if (isDev()) {
         promptForTs();

--- a/apps/cli/src/commands/start.ts
+++ b/apps/cli/src/commands/start.ts
@@ -23,8 +23,8 @@ export default (cli: Command) => {
       }
       if (process.argv.includes('-h') || process.argv.includes('--help')) {
         promptForTs();
-        run('ts-node', [
-          '-P',
+        run('tsx', [
+          '--tsconfig',
           process.env.SERVER_TSCONFIG_PATH ?? '',
           '-r',
           'tsconfig-paths/register',

--- a/apps/cli/src/util.ts
+++ b/apps/cli/src/util.ts
@@ -76,7 +76,7 @@ export function hasCorePackages() {
 }
 
 export function hasTsNode() {
-  return isPackageValid('ts-node/dist/bin');
+  return isPackageValid('tsx');
 }
 
 export function isDev() {

--- a/packages/plugin-prototype-print-template/package.json
+++ b/packages/plugin-prototype-print-template/package.json
@@ -13,7 +13,6 @@
     "docxtemplater": "^3.55.8",
     "koa-bodyparser": "^4.4.1",
     "pizzip": "^3.1.7",
-    "ts-node": "10.9.2",
     "typescript": "5.8.3",
     "xml2js": "^0.6.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4512,9 +4512,6 @@ importers:
       pizzip:
         specifier: ^3.1.7
         version: 3.1.7
-      ts-node:
-        specifier: 10.9.2
-        version: 10.9.2(@types/node@20.17.10)(typescript@5.8.3)
       typescript:
         specifier: 5.8.3
         version: 5.8.3
@@ -34754,24 +34751,6 @@ snapshots:
       diff: 4.0.2
       make-error: 1.3.6
       typescript: 4.9.5
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-
-  ts-node@10.9.2(@types/node@20.17.10)(typescript@5.8.3):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.11
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 20.17.10
-      acorn: 8.14.0
-      acorn-walk: 8.3.4
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 5.8.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated CLI tools to use the `tsx` executable instead of `ts-node` for TypeScript execution.
  - Adjusted related command-line flags to match the new tool.
  - Removed the `ts-node` development dependency from the print template plugin package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->