### PR TITLE
fix: database mysql col

### DIFF
--- a/packages/actions/src/actions/list.ts
+++ b/packages/actions/src/actions/list.ts
@@ -1,4 +1,4 @@
-import qs from 'querystring';
+import qs from 'node:querystring';
 import { assign } from '@tachybase/utils';
 
 import { Op, QueryTypes } from 'sequelize';
@@ -91,7 +91,12 @@ async function listWithPagination(ctx: Context) {
   let filterTreeData = [];
   let filterTreeCount = 0;
   if (ctx.action.params.tree && options.filter) {
-    const foreignKey = collection.treeParentField?.foreignKey || 'parentId';
+    let foreignKey =
+      collection.treeParentField?.collection.model.rawAttributes[collection.treeParentField?.foreignKey]?.field ||
+      'parentId';
+    if (!ctx.db.isMySQLCompatibleDialect()) {
+      foreignKey = `"${foreignKey}"`;
+    }
     const params = Object.values(options.filter).flat()[0] || {};
     let dataIds = [];
     if (Object.entries(params).length) {
@@ -106,26 +111,26 @@ async function listWithPagination(ctx: Context) {
       for (const dataId of dataIds) {
         const query = `
         WITH RECURSIVE tree1 AS (
-            SELECT id, "${foreignKey}"
+            SELECT id, ${foreignKey}
             FROM ${collection.name}
             WHERE id = :dataId
 
               UNION ALL
 
-              SELECT p.id, p."${foreignKey}"
+              SELECT p.id, p.${foreignKey}
               FROM tree1 up
-              JOIN ${collection.name} p ON up."${foreignKey}" = p.id
+              JOIN ${collection.name} p ON up.${foreignKey} = p.id
           ),
           tree2 AS (
-              SELECT id, "${foreignKey}"
+              SELECT id, ${foreignKey}
               FROM ${collection.name}
               WHERE id = :dataId
 
               UNION ALL
 
-            SELECT p.id, p."${foreignKey}"
+            SELECT p.id, p.${foreignKey}
             FROM tree2 down
-            JOIN ${collection.name} p ON down.id = p."${foreignKey}"
+            JOIN ${collection.name} p ON down.id = p.${foreignKey}
         )
         SELECT DISTINCT *
         FROM (

--- a/packages/actions/src/actions/list.ts
+++ b/packages/actions/src/actions/list.ts
@@ -62,7 +62,9 @@ function findArgs(ctx: Context) {
     const collection = ctx.db.getCollection(resourceName);
     // tree collection 或者关系表是 tree collection
     if (collection.options.tree && !(associationName && collectionName === collection.name)) {
-      const foreignKey = collection.treeParentField?.foreignKey || 'parentId';
+      const foreignKey =
+        collection.treeParentField?.collection.model.rawAttributes[collection.treeParentField?.foreignKey]?.field ||
+        'parentId';
       assign(params, { filter: { [foreignKey]: null } }, { filter: 'andMerge' });
     }
   }

--- a/packages/client/src/block-provider/hooks/index.ts
+++ b/packages/client/src/block-provider/hooks/index.ts
@@ -185,7 +185,8 @@ export function useCollectValuesToSubmit() {
     if (addChild) {
       const treeParentField = getTreeParentField();
       values[treeParentField?.name ?? 'parent'] = omit(currentRecord?.__parent, ['children']);
-      values[treeParentField?.foreignKey ?? 'parentId'] = currentRecord?.__parent?.id;
+      values[treeParentField?.collection.model.rawAttributes[treeParentField?.foreignKey]?.field ?? 'parentId'] =
+        currentRecord?.__parent?.id;
     }
     return {
       ...values,
@@ -468,7 +469,8 @@ export const useAssociationCreateActionProps = () => {
       if (addChild) {
         const treeParentField = getTreeParentField();
         values[treeParentField?.name ?? 'parent'] = currentRecord;
-        values[treeParentField?.foreignKey ?? 'parentId'] = currentRecord.id;
+        values[treeParentField?.collection.model.rawAttributes[treeParentField?.foreignKey]?.field ?? 'parentId'] =
+          currentRecord.id;
       }
       actionField.data = field.data || {};
       actionField.data.loading = true;

--- a/packages/data-source/src/default-actions/list.ts
+++ b/packages/data-source/src/default-actions/list.ts
@@ -15,7 +15,9 @@ function findArgs(ctx: Context) {
     const [collectionName, associationName] = resourceName.split('.');
     const collection = ctx.db.getCollection(resourceName);
     if (collection.options.tree && !(associationName && collectionName === collection.name)) {
-      const foreignKey = collection.treeParentField?.foreignKey || 'parentId';
+      const foreignKey =
+        collection.treeParentField?.collection.model.rawAttributes[collection.treeParentField?.foreignKey]?.field ||
+        'parentId';
       assign(params, { filter: { [foreignKey]: null } }, { filter: 'andMerge' });
     }
   }

--- a/packages/module-acl/src/server/middlewares/with-acl-meta.ts
+++ b/packages/module-acl/src/server/middlewares/with-acl-meta.ts
@@ -111,7 +111,7 @@ function createWithACLMetaMiddleware() {
       if (collection.options.tree) {
         if (listData.length === 0) return [];
         const getAllNodeIds = (data) => [data[primaryKeyField], ...(data.children || []).flatMap(getAllNodeIds)];
-        return listData.map((tree) => getAllNodeIds(tree.toJSON())).flat();
+        return listData.map((tree) => getAllNodeIds(tree.toJSON ? tree.toJSON() : tree)).flat();
       }
 
       return listData.filter(Boolean).map((item) => item[primaryKeyField]);

--- a/packages/module-auth/src/server/collections/token-blacklist.ts
+++ b/packages/module-auth/src/server/collections/token-blacklist.ts
@@ -9,9 +9,10 @@ export default defineCollection({
   model: 'TokenBlacklistModel',
   fields: [
     {
-      type: 'text',
+      type: 'string',
       name: 'token',
       index: true,
+      length: 512,
     },
     {
       type: 'date',

--- a/packages/module-auth/src/server/migrations/20250626174901-change-token.ts
+++ b/packages/module-auth/src/server/migrations/20250626174901-change-token.ts
@@ -9,7 +9,7 @@ export default class extends Migration {
     // 获取当前数据库中所有表名
     const tables: string[] = await this.db.sequelize.getQueryInterface().showAllTables();
     if (!tables.includes('tokenBlacklist')) {
-      this.app.logger.info(`[migration skipped] table webhooks does not exist`);
+      this.app.logger.info(`[migration skipped] table tokenBlacklist does not exist`);
       return;
     }
     const queryInterface = this.db.sequelize.getQueryInterface();

--- a/packages/module-auth/src/server/migrations/20250626174901-change-token.ts
+++ b/packages/module-auth/src/server/migrations/20250626174901-change-token.ts
@@ -1,0 +1,23 @@
+import { DataTypes } from '@tachybase/database';
+import { Migration } from '@tachybase/server';
+
+export default class extends Migration {
+  on = 'beforeLoad'; // 'beforeLoad' or 'afterLoad'
+  appVersion = '<1.3.11';
+
+  async up() {
+    // 获取当前数据库中所有表名
+    const tables: string[] = await this.db.sequelize.getQueryInterface().showAllTables();
+    if (!tables.includes('tokenBlacklist')) {
+      this.app.logger.info(`[migration skipped] table webhooks does not exist`);
+      return;
+    }
+    const queryInterface = this.db.sequelize.getQueryInterface();
+    // 使用 changeColumn 方法来修改列的数据类型
+    await queryInterface.changeColumn('tokenBlacklist', 'token', {
+      type: DataTypes.STRING(512),
+    });
+
+    this.app.logger.info('tokenBlacklist token change string(512) success!');
+  }
+}

--- a/packages/plugin-api-keys/src/collections/apiKeys.ts
+++ b/packages/plugin-api-keys/src/collections/apiKeys.ts
@@ -89,8 +89,9 @@ export default {
     },
     {
       name: 'token',
-      type: 'text',
+      type: 'string',
       hidden: true,
+      length: 512,
     },
     {
       name: 'accessToken',

--- a/packages/plugin-api-keys/src/server/migrations/20250626175519-change-token.ts
+++ b/packages/plugin-api-keys/src/server/migrations/20250626175519-change-token.ts
@@ -9,7 +9,7 @@ export default class extends Migration {
     // 获取当前数据库中所有表名
     const tables: string[] = await this.db.sequelize.getQueryInterface().showAllTables();
     if (!tables.includes('apiKeys')) {
-      this.app.logger.info(`[migration skipped] table webhooks does not exist`);
+      this.app.logger.info(`[migration skipped] table apiKeys does not exist`);
       return;
     }
     const queryInterface = this.db.sequelize.getQueryInterface();

--- a/packages/plugin-api-keys/src/server/migrations/20250626175519-change-token.ts
+++ b/packages/plugin-api-keys/src/server/migrations/20250626175519-change-token.ts
@@ -1,0 +1,23 @@
+import { DataTypes } from '@tachybase/database';
+import { Migration } from '@tachybase/server';
+
+export default class extends Migration {
+  on = 'beforeLoad'; // 'beforeLoad' or 'afterLoad'
+  appVersion = '<1.3.11';
+
+  async up() {
+    // 获取当前数据库中所有表名
+    const tables: string[] = await this.db.sequelize.getQueryInterface().showAllTables();
+    if (!tables.includes('apiKeys')) {
+      this.app.logger.info(`[migration skipped] table webhooks does not exist`);
+      return;
+    }
+    const queryInterface = this.db.sequelize.getQueryInterface();
+    // 使用 changeColumn 方法来修改列的数据类型
+    await queryInterface.changeColumn('apiKeys', 'token', {
+      type: DataTypes.STRING(512),
+    });
+
+    this.app.logger.info('apiKeys token change string(512) success!');
+  }
+}

--- a/packages/plugin-full-text-search/src/server/dialects/FieldBase.ts
+++ b/packages/plugin-full-text-search/src/server/dialects/FieldBase.ts
@@ -108,7 +108,7 @@ export class FieldBase {
   }
 
   protected getCollectionField(fieldName: string, collection: Collection, collectionName?: string) {
-    let rawFieldName = '';
+    let rawFieldName = fieldName;
     if (collection) {
       rawFieldName = collection.model.rawAttributes[fieldName]?.field || fieldName;
     }

--- a/packages/plugin-full-text-search/src/server/dialects/FieldPostgres.ts
+++ b/packages/plugin-full-text-search/src/server/dialects/FieldPostgres.ts
@@ -24,7 +24,7 @@ export class FieldPostgres extends FieldBase {
   }
 
   public date(params: handleFieldParams): any {
-    const { field, keyword, dateStr, timezone, collectionName } = params;
+    const { field, keyword, dateStr, timezone, collectionName, collection } = params;
     return {
       [Op.and]: [
         where(
@@ -33,7 +33,7 @@ export class FieldPostgres extends FieldBase {
             fn(
               'TIMEZONE',
               timezone, // 参数1：目标时区
-              fn('TIMEZONE', 'UTC', this.getCollectionField(field, collectionName)), // 参数2：UTC 转换后的字段
+              fn('TIMEZONE', 'UTC', this.getCollectionField(field, collection, collectionName)), // 参数2：UTC 转换后的字段
             ),
             dateStr, // 参数3：格式化字符串
           ),
@@ -56,7 +56,7 @@ export class FieldPostgres extends FieldBase {
   }
 
   public number(params: handleFieldParams): WhereOptions<any> {
-    const { field, keyword, collectionName } = params;
+    const { field, keyword, collectionName, collection } = params;
     // keyword不是数字则不作为搜索条件
     if (isNaN(Number(keyword))) {
       return null;
@@ -64,7 +64,7 @@ export class FieldPostgres extends FieldBase {
     return {
       [Op.and]: [
         where(
-          literal(`CAST(${this.getCollectionFieldColName(field, collectionName)} AS TEXT)`), // 确保不加引号，直接插入 SQL 表达式
+          literal(`CAST(${this.getCollectionFieldColName(field, collection, collectionName)} AS TEXT)`), // 确保不加引号，直接插入 SQL 表达式
           {
             [Op.like]: `%${escapeLike(keyword)}%`,
           },

--- a/packages/plugin-full-text-search/src/server/searchField.ts
+++ b/packages/plugin-full-text-search/src/server/searchField.ts
@@ -45,6 +45,7 @@ export function handleField(
     timezone?: string;
     dateStr?: string;
     collectionName?: string;
+    collection?: Collection;
   } = {},
 ): any[] {
   const conditions = [];
@@ -56,6 +57,7 @@ export function handleField(
       timezone: extraParams.timezone,
       dateStr: extraParams.dateStr,
       collectionName: extraParams.collectionName,
+      collection: extraParams.collection,
     };
     const condition = func.call(handler, params);
     if (condition) {
@@ -86,12 +88,13 @@ export function processField({ field, handler, collection, ctx, search, timezone
 
   if (isFieldType(type, 'string')) {
     // string支持关联字段
-    return handleField(handler, handler.string, field, fields, search.keywords);
+    return handleField(handler, handler.string, field, fields, search.keywords, { collection });
   } else if (isFieldType(type, 'number')) {
     // 暂不支持关联字段 TODO 后续考虑抽成装饰器
     if (!field.includes('.')) {
       return handleField(handler, handler.number, field, fields, search.keywords, {
         collectionName: collection.name,
+        collection,
       });
     }
   } else if (isFieldType(type, 'date')) {
@@ -103,17 +106,18 @@ export function processField({ field, handler, collection, ctx, search, timezone
         timezone,
         dateStr,
         collectionName: collection.name,
+        collection,
       });
     }
   } else if (isFieldType(type, 'json')) {
     // 暂不支持关联字段
     if (!field.includes('.')) {
-      return handleField(handler, handler.json, field, fields, search.keywords);
+      return handleField(handler, handler.json, field, fields, search.keywords, { collection });
     }
   } else if (isFieldType(type, 'array')) {
     // 暂不支持关联字段
     if (!field.includes('.')) {
-      return handleField(handler, handler.array, field, fields, search.keywords);
+      return handleField(handler, handler.array, field, fields, search.keywords, { collection });
     }
   }
 

--- a/packages/plugin-full-text-search/src/server/types.ts
+++ b/packages/plugin-full-text-search/src/server/types.ts
@@ -29,4 +29,5 @@ export type handleFieldParams = {
   fields: Map<string, any>;
   timezone?: string;
   dateStr?: string;
+  collection?: Collection;
 };


### PR DESCRIPTION
DB_UNDERSCORED=true 的情况下全文搜索出错

mysql不支持text做索引

调整mysql的null排序排在最后

树形表的筛选搜索

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sorting behavior for MySQL-compatible databases, ensuring more accurate handling of null values when sorting by both direct and association-based fields.
  * Fixed potential runtime errors in ACL middleware by safely handling tree nodes without `toJSON` methods.

* **New Features**
  * Enhanced field processing in full-text search to more accurately resolve database column names by including collection context in filtering and casting operations.

* **Chores**
  * Updated database schema for API key and token blacklist tables, changing token fields from text to string with a maximum length of 512 characters.
  * Added database migrations to support token field type and length changes for existing installations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->