### PR TITLE
style: update share page styles and disable designer mode

### DIFF
--- a/packages/client/src/application/components/SharePage.tsx
+++ b/packages/client/src/application/components/SharePage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useContext, useEffect, useMemo, useRef } from 'react';
 import { useFieldSchema } from '@tachybase/schema';
 
 import { css } from '@emotion/css';
@@ -8,16 +8,17 @@ import { Outlet } from 'react-router-dom';
 
 import { useAPIClient } from '../../api-client';
 import { AdminProvider, AdminTabs, MenuEditor, useStyles } from '../../built-in/admin-layout';
+import { ContextMenuContext, useContextMenu } from '../../built-in/context-menu';
 import { PinnedPluginList } from '../../built-in/pinned-list';
 import { useSystemSettings } from '../../built-in/system-settings';
 import { CurrentUser } from '../../user';
-import { useApp } from '../hooks';
+import { useApp, useApp as useAppContext } from '../hooks';
 
 export function useShareToken() {
   const url = new URL(window.location.href);
   const api = useAPIClient();
   const token = url.searchParams.get('token');
-  return token && api.auth.setToken(token), api.auth.getToken();
+  return (token && api.auth.setToken(token), api.auth.getToken());
 }
 
 export const ShareLayout = () => {
@@ -25,7 +26,36 @@ export const ShareLayout = () => {
   const app = useApp();
   const result = useSystemSettings();
   const sideMenuRef = useRef<HTMLDivElement>();
+
+  // 隐藏右键菜单中的设计者模式选项
+  useEffect(() => {
+    const hideDesignerModeMenuItem = () => {
+      const menuItems = document.querySelectorAll('.ant-dropdown-menu-item');
+      menuItems.forEach((item) => {
+        const text = item.textContent || '';
+        if (text.includes('Designer mode') || text.includes('设计者模式')) {
+          (item as HTMLElement).style.display = 'none';
+        }
+      });
+    };
+
+    // 监听右键菜单
+    const observer = new MutationObserver(hideDesignerModeMenuItem);
+    observer.observe(document.body, {
+      childList: true,
+      subtree: true,
+    });
+
+    // 初始检查
+    hideDesignerModeMenuItem();
+
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
+
   return (
+    // 修改页面样式
     <Layout style={{ height: '100%' }}>
       <Layout.Content
         className={css`
@@ -33,6 +63,10 @@ export const ShareLayout = () => {
           flex-direction: column;
           position: relative;
           overflow-y: auto;
+          height: 600px;
+          width: 1200px;
+          margin: 50px auto;
+          box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.7);
           > div {
             position: relative;
           }
@@ -44,9 +78,21 @@ export const ShareLayout = () => {
             z-index: 0;
             padding: 0px 50px;
           }
+          /* 页面标题居中 */
+          .ant-page-header-heading {
+            justify-content: center !important;
+          }
+          .ant-page-header-heading-left {
+            justify-content: center !important;
+            text-align: center !important;
+          }
+          .ant-page-header-heading-title {
+            text-align: center !important;
+          }
         `}
       >
-        <Layout.Header className={styles.header}>
+        {/* 删除头部菜单 */}
+        {/* <Layout.Header className={styles.header}>
           <div className={styles.headerA}>
             <div className={styles.headerB}>
               <div
@@ -68,11 +114,38 @@ export const ShareLayout = () => {
               <CurrentUser />
             </div>
           </div>
-        </Layout.Header>
+        </Layout.Header> */}
         <Outlet />
       </Layout.Content>
     </Layout>
   );
+};
+
+// 自定义分享页面右键菜单
+const ShareContextMenuProvider = ({ children }) => {
+  const app = useAppContext();
+  const originalContextMenuContext = useContext(ContextMenuContext);
+
+  // 过滤后
+  const filteredContextMenuContext = useMemo(() => {
+    if (!originalContextMenuContext) return originalContextMenuContext;
+
+    const contextItems = app.pluginContextMenu.get();
+    const filteredItems = {};
+
+    // 过滤设计者模式选项
+    Object.keys(contextItems).forEach((key) => {
+      if (key !== 'designerMode') {
+        filteredItems[key] = contextItems[key];
+      }
+    });
+
+    return {
+      ...originalContextMenuContext,
+    };
+  }, [originalContextMenuContext, app]);
+
+  return <ContextMenuContext.Provider value={filteredContextMenuContext}>{children}</ContextMenuContext.Provider>;
 };
 
 export const SharePage = () => {
@@ -82,7 +155,9 @@ export const SharePage = () => {
     <NotAuthorityResult />
   ) : (
     <AdminProvider>
-      <ShareLayout />
+      <ShareContextMenuProvider>
+        <ShareLayout />
+      </ShareContextMenuProvider>
     </AdminProvider>
   );
 };

--- a/packages/client/src/application/components/ShareSchemaComponent.tsx
+++ b/packages/client/src/application/components/ShareSchemaComponent.tsx
@@ -1,9 +1,15 @@
 import { useParams } from 'react-router';
 
-import { RemoteSchemaComponent } from '../../schema-component';
+import { RemoteSchemaComponent, SchemaComponentContext, useSchemaComponentContext } from '../../schema-component';
 
 export function ShareSchemaComponent() {
   const params = useParams();
+  const context = useSchemaComponentContext();
 
-  return <RemoteSchemaComponent uid={params.name} />;
+  return (
+    // 分享页禁用设计者模式
+    <SchemaComponentContext.Provider value={{ ...context, designable: false }}>
+      <RemoteSchemaComponent uid={params.name} />
+    </SchemaComponentContext.Provider>
+  );
 }

--- a/packages/client/src/built-in/context-menu/ContextMenu.provider.tsx
+++ b/packages/client/src/built-in/context-menu/ContextMenu.provider.tsx
@@ -31,13 +31,20 @@ export const ContextMenuProvider = ({ children }) => {
   const contextItemsSorted = Object.values(contextItems).sort((a, b) => (a.sort || 0) - (b.sort || 0));
 
   contextItemsSorted.forEach((item) => {
-    const { actionProps, title, icon } = item.useLoadMethod({
+    const result = item.useLoadMethod({
       enable,
       setEnable,
       showScrollArea,
       setShowScrollArea,
       position,
     });
+
+    // 如果 useLoadMethod 返回 null，跳过该项
+    if (!result) {
+      return;
+    }
+
+    const { actionProps, title, icon } = result;
     items.push({
       label: title,
       key: title,

--- a/packages/client/src/built-in/context-menu/ContextMenuItemsProps.tsx
+++ b/packages/client/src/built-in/context-menu/ContextMenuItemsProps.tsx
@@ -11,6 +11,15 @@ export const designerMode = {
   useLoadMethod: () => {
     const { designable, setDesignable } = useDesignable() as any;
     const { t } = useTranslation();
+
+    // 检测是否在分享页面
+    const isSharePage = typeof window !== 'undefined' && window.location.pathname.includes('/share');
+
+    // 如果是分享页面，返回 null 表示不显示此选项
+    if (isSharePage) {
+      return null;
+    }
+
     return {
       title: t('Designer mode'),
       actionProps: {


### PR DESCRIPTION
修改1：禁用设计者模式
在ShareSchemaComponent中包裹一个SchemaComponentContext.Provider来覆盖designable值为false，这样不影响页面的正常渲染，只会在分享页面禁用设计者模式。在SharePage.tsx中添加useEffect和MutationObserver来动态监听和隐藏右键菜单中的"设计者模式"选项，查找并隐藏包含"Designer mode"或"设计者模式"文本的菜单项。所有改动均在share相关界面中，不影响公共组件。
修改2&3：删除头部菜单，修改页面样式
在SharePage.tsx里直接修改css样式，删除不需要的头部组件。
![share_page_style](https://github.com/user-attachments/assets/c7a5ad44-56b2-4aea-bad1-1c3ad166f740)
