### PR TITLE
refactor: sub app upgrade after sub app self start

### DIFF
--- a/packages/module-multi-app/src/client/base/schemas/schemaForm.ts
+++ b/packages/module-multi-app/src/client/base/schemas/schemaForm.ts
@@ -21,17 +21,17 @@ export const formSchema: ISchema = {
     //   'x-decorator': 'FormItem',
     //   'x-content': i18nText('Standalone deployment'),
     // },
-    'options.autoStart': {
-      title: i18nText('Start mode'),
-      'x-component': 'Radio.Group',
-      'x-decorator': 'FormItem',
-      default: false,
-      enum: [
-        { label: i18nText('Start on first visit'), value: false },
-        { label: i18nText('Start with main application'), value: true },
-      ],
-      'x-hidden': '{{ !admin }}',
-    },
+    // 'options.autoStart': {
+    //   title: i18nText('Start mode'),
+    //   'x-component': 'Radio.Group',
+    //   'x-decorator': 'FormItem',
+    //   default: false,
+    //   enum: [
+    //     { label: i18nText('Start on first visit'), value: false },
+    //     { label: i18nText('Start with main application'), value: true },
+    //   ],
+    //   'x-hidden': '{{ !admin }}',
+    // },
     cnamePrefix: {
       title: i18nText('Custom domain prefix'),
       'x-component': 'Input',

--- a/packages/module-multi-app/src/server/server.ts
+++ b/packages/module-multi-app/src/server/server.ts
@@ -232,11 +232,11 @@ export class PluginMultiAppManager extends Plugin {
 
     Gateway.getInstance().addAppSelectorMiddleware(appSelectorMiddleware(this.app));
 
-    this.app.on('afterStart', onAfterStart(this.db));
+    // this.app.on('afterStart', onAfterStart(this.db));
 
-    this.app.on('afterUpgrade', async (app, options) => {
-      await this.subAppUpgradeHandler(app);
-    });
+    // this.app.on('afterUpgrade', async (app, options) => {
+    //   await this.subAppUpgradeHandler(app);
+    // });
 
     const notifyStatusChange = this.notifyStatusChange.bind(this);
     this.app.on('beforeStop', async (app) => {


### PR DESCRIPTION
子应用不再随主应用启动而启动
子应用自身的更新也是随自己启动而更新

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Disabled the "Start Mode" selection field in the form, so users will no longer see or interact with this option.
  * Lifecycle event handling for application start and upgrade has been disabled, with no visible impact on current user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->