### PR TITLE
fix: reset pwd null

### DIFF
--- a/packages/module-auth/src/server/basic-auth.ts
+++ b/packages/module-auth/src/server/basic-auth.ts
@@ -1,4 +1,4 @@
-import crypto from 'crypto';
+import crypto from 'node:crypto';
 import { AuthConfig, BaseAuth } from '@tachybase/auth';
 import { PasswordField } from '@tachybase/database';
 
@@ -140,9 +140,11 @@ export class BasicAuth extends BaseAuth {
       },
     });
     const pwd = this.userCollection.getField<PasswordField>('password');
-    const isValid = await pwd.verify(oldPassword, user.password);
-    if (!isValid) {
-      ctx.throw(401, ctx.t('The username, email or password is incorrect, please re-enter', { ns: namespace }));
+    if (user.password !== null) {
+      const isValid = await pwd.verify(oldPassword, user.password);
+      if (!isValid) {
+        ctx.throw(401, ctx.t('The username, email or password is incorrect, please re-enter', { ns: namespace }));
+      }
     }
     user.password = newPassword;
     await user.save();


### PR DESCRIPTION
当用户通过短信,微信等方式登录时允许用户重新设置自己密码

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The password change form now conditionally hides the "Old password" field if the user does not have an existing password.

* **Bug Fixes**
  * Ensured that the old password is only verified when the user actually has a password set.

* **Chores**
  * Improved handling of user context and UI updates after a password change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->