### PR TITLE
chore: remove ts command line

### DIFF
--- a/.github/workflows/release-new-version.yaml
+++ b/.github/workflows/release-new-version.yaml
@@ -95,10 +95,10 @@ jobs:
         with:
           tag_name: ${{ needs.release.outputs.version }}
           files: |
-            apps/tego/dist/tego-linux-x64
-            apps/tego/dist/tego-macos-x64
-            apps/tego/dist/tego-win-x64.exe
-            apps/tego/dist/tego-linux-arm64
-            apps/tego/dist/tego-macos-arm64
+            packages/tego/dist/tego-linux-x64
+            packages/tego/dist/tego-macos-x64
+            packages/tego/dist/tego-win-x64.exe
+            packages/tego/dist/tego-linux-arm64
+            packages/tego/dist/tego-macos-arm64
 
 

--- a/packages/empty-ts-command-line/package.json
+++ b/packages/empty-ts-command-line/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@tachybase/empty-ts-command-line",
+  "version": "1.0.0",
+  "main": "lib/index.js"
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,7 @@ overrides:
   string-width: 4.2.3
   strip-ansi: 6.0.1
   wrap-ansi: 7.0.0
+  umzug>@rushstack/ts-command-line: '@tachybase/empty-ts-command-line@workspace:*'
 
 importers:
 
@@ -535,6 +536,8 @@ importers:
       esbuild-plugin-file-path-extensions:
         specifier: ^2.1.4
         version: 2.1.4
+
+  packages/empty-ts-command-line: {}
 
   packages/evaluators:
     dependencies:
@@ -3499,9 +3502,6 @@ packages:
       webpack-hot-middleware:
         optional: true
 
-  '@rushstack/ts-command-line@4.17.1':
-    resolution: {integrity: sha512-2jweO1O57BYP5qdBGl6apJLB+aRIn5ccIRTPDyULh0KMwVzFqWtw6IZWt1qtUoZD/pD2RNkIOosH6Cq45rIYeg==}
-
   '@sigstore/bundle@3.1.0':
     resolution: {integrity: sha512-Mm1E3/CmDDCz3nDhFKTuYdB47EdRFRQMOE/EAbiG1MJW77/w1b3P7Qx7JSrVJs8PfwOLOVcKQCHErIwCTyPbag==}
     engines: {node: ^18.17.0 || >=20.5.0}
@@ -3594,9 +3594,6 @@ packages:
 
   '@types/accepts@1.3.7':
     resolution: {integrity: sha512-Pay9fq2lM2wXPWbteBsRAGiWH2hig4ZE2asK+mm7kUzlxRTfL961rj89I6zV/E3PcIkDqyuBEcMxFT7rccugeQ==}
-
-  '@types/argparse@1.0.38':
-    resolution: {integrity: sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==}
 
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
@@ -4087,9 +4084,6 @@ packages:
   arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
 
-  argparse@1.0.10:
-    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
-
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
@@ -4512,10 +4506,6 @@ packages:
 
   colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
-
-  colors@1.2.5:
-    resolution: {integrity: sha512-erNRLao/Y3Fv54qUa0LBB+//Uf3YwMUmdJinN20yMXm9zdKKqH9wt7R9IIVZ+K7ShzfpLV/Zg8+VyrBJYB4lpg==}
-    engines: {node: '>=0.1.90'}
 
   colorspace@1.1.4:
     resolution: {integrity: sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==}
@@ -7924,9 +7914,6 @@ packages:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
 
-  sprintf-js@1.0.3:
-    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
-
   sprintf-js@1.1.3:
     resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
 
@@ -11214,13 +11201,6 @@ snapshots:
       html-entities: 2.6.0
       react-refresh: 0.17.0
 
-  '@rushstack/ts-command-line@4.17.1':
-    dependencies:
-      '@types/argparse': 1.0.38
-      argparse: 1.0.10
-      colors: 1.2.5
-      string-argv: 0.3.2
-
   '@sigstore/bundle@3.1.0':
     dependencies:
       '@sigstore/protobuf-specs': 0.4.3
@@ -11379,8 +11359,6 @@ snapshots:
   '@types/accepts@1.3.7':
     dependencies:
       '@types/node': 20.17.10
-
-  '@types/argparse@1.0.38': {}
 
   '@types/aria-query@5.0.4': {}
 
@@ -12046,10 +12024,6 @@ snapshots:
 
   arg@5.0.2: {}
 
-  argparse@1.0.10:
-    dependencies:
-      sprintf-js: 1.0.3
-
   argparse@2.0.1: {}
 
   aria-query@5.3.0:
@@ -12559,8 +12533,6 @@ snapshots:
       color-string: 1.9.1
 
   colorette@2.0.20: {}
-
-  colors@1.2.5: {}
 
   colorspace@1.1.4:
     dependencies:
@@ -16242,8 +16214,6 @@ snapshots:
 
   split2@4.2.0: {}
 
-  sprintf-js@1.0.3: {}
-
   sprintf-js@1.1.3: {}
 
   sql-formatter@15.6.5:
@@ -16617,7 +16587,7 @@ snapshots:
 
   umzug@3.8.2:
     dependencies:
-      '@rushstack/ts-command-line': 4.17.1
+      '@rushstack/ts-command-line': link:@tachybase/empty-ts-command-line@workspace:*
       emittery: 0.13.1
       fast-glob: 3.3.3
       pony-cause: 2.1.10

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,8 +19,7 @@ overrides:
   "strip-ansi": "6.0.1"
   "wrap-ansi": "7.0.0"
   "umzug>@rushstack/ts-command-line": "@tachybase/empty-ts-command-line@workspace:*"
-
-neverBuiltDependencies:
+ignoredBuiltDependencies:
 - canvas
 
 # force isolated to keep sync with partners

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,6 +18,7 @@ overrides:
   "string-width": "4.2.3"
   "strip-ansi": "6.0.1"
   "wrap-ansi": "7.0.0"
+  "umzug>@rushstack/ts-command-line": "@tachybase/empty-ts-command-line@workspace:*"
 
 neverBuiltDependencies:
 - canvas


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated internal workflow to use a new directory structure for release assets.
  * Added a new package configuration for "@tachybase/empty-ts-command-line".
  * Adjusted workspace dependency overrides to use the new package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->