### PR TITLE
fix: treat @tego/client and @tego/server as internal dependencies

### DIFF
--- a/packages/devkit/src/builder/buildable-packages/plugin-package.ts
+++ b/packages/devkit/src/builder/buildable-packages/plugin-package.ts
@@ -55,6 +55,8 @@ const external = [
   '@tachybase/utils',
   '@tachybase/globals',
   '@tachybase/loader',
+  '@tego/client',
+  '@tego/server',
 
   // @tachybase/auth
   'jsonwebtoken',

--- a/packages/loader/src/index.ts
+++ b/packages/loader/src/index.ts
@@ -11,7 +11,7 @@ export const defineLoader = (
   function (request, parent, isMain) {
     // 使用白名单拦截，以及所有符合 '@tachybase/' 前缀的包
     // TODO 未来支持动态的前缀判定或者更严格的判定
-    if (whitelists.has(request) || request.startsWith('@tachybase/')) {
+    if (whitelists.has(request) || request.startsWith('@tachybase/') || request.startsWith('@tego/')) {
       try {
         const resolvedFromApp = require.resolve(request, { paths: lookingPaths });
         return originalLoad(resolvedFromApp, parent, isMain);

--- a/packages/server/src/plugin-manager/constants.ts
+++ b/packages/server/src/plugin-manager/constants.ts
@@ -21,6 +21,8 @@ export const EXTERNAL = [
   '@tachybase/utils',
   '@tachybase/globals',
   '@tachybase/loader',
+  '@tego/client',
+  '@tego/server',
 
   // @tachybase/auth
   'jsonwebtoken',

--- a/packages/server/src/plugin-manager/deps.ts
+++ b/packages/server/src/plugin-manager/deps.ts
@@ -1,7 +1,8 @@
 import { version } from '../../package.json';
 
 const deps: Record<string, string> = {
-  '@tachybase': `${version.split('.').slice(0, 2).join('.')}.x`, // 0.12.x
+  '@tachybase': `${version.split('.').slice(0, 2).join('.')}.x`,
+  '@tego': `${version.split('.').slice(0, 2).join('.')}.x`,
 
   jsonwebtoken: '8.x',
   'cache-manager': '5.x',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for packages with the '@tego/' prefix in the loader and build process.
  * '@tego/client' and '@tego/server' are now recognized as external dependencies.

* **Chores**
  * Updated dependency management to include the '@tego' package with version compatibility handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->