### PR TITLE
fix: tego_runtime_home should not ends with storage

### DIFF
--- a/packages/devkit/src/util.ts
+++ b/packages/devkit/src/util.ts
@@ -374,7 +374,7 @@ export function initEnv() {
     !process.env.TEGO_RUNTIME_NAME &&
     _existsSync(resolve(process.cwd(), 'storage'))
   ) {
-    process.env.TEGO_RUNTIME_HOME = resolve(process.cwd(), 'storage');
+    process.env.TEGO_RUNTIME_HOME = process.cwd();
   }
 
   for (const key in env) {

--- a/packages/tego/src/utils.ts
+++ b/packages/tego/src/utils.ts
@@ -78,7 +78,7 @@ export function parseEnvironment() {
     !process.env.TEGO_RUNTIME_NAME &&
     fs.existsSync(resolve(process.cwd(), 'storage'))
   ) {
-    process.env.TEGO_RUNTIME_HOME = resolve(process.cwd(), 'storage');
+    process.env.TEGO_RUNTIME_HOME = process.cwd();
   }
 
   for (const key in env) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated environment variable handling to set the runtime home directory to the current working directory instead of a subdirectory under certain conditions. This may affect where runtime data is stored or accessed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->