### PR TITLE
refactor(core): replace Koa inheritance with EventEmitter

### DIFF
--- a/packages/acl/package.json
+++ b/packages/acl/package.json
@@ -6,6 +6,7 @@
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "dependencies": {
+    "@tachybase/actions": "workspace:*",
     "@tachybase/resourcer": "workspace:*",
     "@tachybase/utils": "workspace:*",
     "koa-compose": "^4.1.0",
@@ -14,6 +15,7 @@
   },
   "devDependencies": {
     "@types/lodash": "4.17.20",
+    "@types/minimatch": "^6.0.0",
     "@types/node": "20.17.10"
   }
 }

--- a/packages/acl/src/acl.ts
+++ b/packages/acl/src/acl.ts
@@ -1,4 +1,5 @@
 import EventEmitter from 'node:events';
+import { Context } from '@tachybase/actions';
 import { Action } from '@tachybase/resourcer';
 import { assign, getCurrentStacks, parseFilter, Toposort, ToposortOptions } from '@tachybase/utils';
 
@@ -328,7 +329,7 @@ export class ACL extends EventEmitter {
   /**
    * @internal
    */
-  async parseJsonTemplate(json: any, ctx: any) {
+  async parseJsonTemplate(json: any, ctx: Context) {
     if (json.filter) {
       ctx.logger?.info?.('parseJsonTemplate.raw', JSON.parse(JSON.stringify(json.filter)));
       const timezone = ctx?.get?.('x-timezone');
@@ -445,29 +446,28 @@ export class ACL extends EventEmitter {
     const acl = this;
 
     this.middlewares.add(
-      async (ctx, next) => {
+      async (ctx: Context, next) => {
         const resourcerAction: Action = ctx.action;
         const { resourceName, actionName } = ctx.permission;
 
         const permission = ctx.permission;
 
-        ctx.log?.info && ctx.log.info('ctx permission', permission);
+        ctx.logger?.info('ctx permission', permission);
 
         if ((!permission.can || typeof permission.can !== 'object') && !permission.skip) {
           ctx.throw(403, 'No permissions');
-          return;
         }
 
         const params = permission.can?.params || acl.fixedParamsManager.getParams(resourceName, actionName);
 
-        ctx.log?.info && ctx.log.info('acl params', params);
+        ctx.logger?.info('acl params', params);
 
         if (params && resourcerAction.mergeParams) {
           const filteredParams = acl.filterParams(ctx, resourceName, params);
           const parsedParams = await acl.parseJsonTemplate(filteredParams, ctx);
 
           ctx.permission.parsedParams = parsedParams;
-          ctx.log?.info && ctx.log.info('acl parsedParams', parsedParams);
+          ctx.logger?.info('acl parsedParams', parsedParams);
           ctx.permission.rawParams = lodash.cloneDeep(resourcerAction.params);
           resourcerAction.mergeParams(parsedParams, {
             appends: (x, y) => {
@@ -497,7 +497,7 @@ export class ACL extends EventEmitter {
   }
 }
 
-function getUser(ctx) {
+function getUser(ctx: Context) {
   return async ({ fields }) => {
     const userFields = fields.filter((f) => f && ctx.db.getFieldByPath('users.' + f));
     ctx.logger?.info('filter-parse: ', { userFields });

--- a/packages/acl/src/allow-manager.ts
+++ b/packages/acl/src/allow-manager.ts
@@ -1,3 +1,5 @@
+import { Context } from '@tachybase/actions';
+
 import { ACL } from './acl';
 
 export type ConditionFunc = (ctx: any) => Promise<boolean> | boolean;
@@ -8,7 +10,7 @@ export class AllowManager {
   protected registeredCondition = new Map<string, ConditionFunc>();
 
   constructor(public acl: ACL) {
-    this.registerAllowCondition('loggedIn', (ctx) => {
+    this.registerAllowCondition('loggedIn', (ctx: Context) => {
       return ctx.state.currentUser;
     });
 

--- a/packages/auth/src/auth-manager.ts
+++ b/packages/auth/src/auth-manager.ts
@@ -109,7 +109,7 @@ export class AuthManager {
       const name = ctx.get(self.options.authKey) || self.options.default;
       let authenticator: Auth;
       try {
-        authenticator = await ctx.app.authManager.get(name, ctx);
+        authenticator = await ctx.tego.authManager.get(name, ctx);
         ctx.auth = authenticator;
       } catch (err) {
         ctx.auth = {} as Auth;

--- a/packages/auth/src/auth.ts
+++ b/packages/auth/src/auth.ts
@@ -64,7 +64,7 @@ export abstract class Auth implements IAuth {
 
   async skipCheck() {
     const token = this.ctx.getBearerToken();
-    if (!token && this.ctx.app.options.acl === false) {
+    if (!token && this.ctx.tego.options.acl === false) {
       return true;
     }
     const { resourceName, actionName } = this.ctx.action;

--- a/packages/auth/src/base/auth.ts
+++ b/packages/auth/src/base/auth.ts
@@ -29,11 +29,11 @@ export class BaseAuth extends Auth {
   }
 
   get jwt(): JwtService {
-    return this.ctx.app.authManager.jwt;
+    return this.ctx.tego.authManager.jwt;
   }
 
   get tokenController(): ITokenControlService {
-    return this.ctx.app.authManager.tokenController;
+    return this.ctx.tego.authManager.tokenController;
   }
 
   set user(user: Model) {
@@ -89,7 +89,7 @@ export class BaseAuth extends Auth {
     const { userId, roleName, iat, temp, jti, exp, signInTime } = payload ?? {};
 
     const user = userId
-      ? await this.ctx.app.cache.wrap(this.getCacheKey(userId), () =>
+      ? await this.ctx.tego.cache.wrap(this.getCacheKey(userId), () =>
           this.userRepository.findOne({
             filter: {
               id: userId,
@@ -311,7 +311,7 @@ export class BaseAuth extends Auth {
         });
       }
     }
-    await this.ctx.app.emitAsync('cache:del:roles', { userId });
+    await this.ctx.tego.emitAsync('cache:del:roles', { userId });
     await this.ctx.cache.del(this.getCacheKey(userId));
     return await this.jwt.block(token);
   }

--- a/packages/core/src/application.ts
+++ b/packages/core/src/application.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'node:crypto';
 import { IncomingMessage, ServerResponse } from 'node:http';
 import { basename, resolve } from 'node:path';
 import { RecordableHistogram } from 'node:perf_hooks';
+import { EventEmitter } from 'node:stream';
 import { registerActions } from '@tachybase/actions';
 import { actions as authActions, AuthManager, AuthManagerOptions } from '@tachybase/auth';
 import { Cache, CacheManager, CacheManagerOptions } from '@tachybase/cache';
@@ -31,8 +32,7 @@ import {
 import { Command, CommanderError, CommandOptions, ParseOptions } from 'commander';
 import { globSync } from 'glob';
 import { i18n, InitOptions } from 'i18next';
-import Koa, { DefaultContext as KoaDefaultContext, DefaultState as KoaDefaultState } from 'koa';
-import compose from 'koa-compose';
+import Koa from 'koa';
 import lodash from 'lodash';
 import _ from 'lodash';
 import { nanoid } from 'nanoid';
@@ -121,39 +121,26 @@ export interface ApplicationOptions {
   tmpl?: any;
 }
 
-export interface DefaultState extends KoaDefaultState {
-  currentUser?: any;
-
-  [key: string]: any;
+declare module 'koa' {
+  interface DefaultState {
+    currentUser?: any;
+  }
 }
 
-export interface DefaultContext extends KoaDefaultContext {
-  db: Database;
-  cache: Cache;
-  resourcer: Resourcer;
-  i18n: any;
+declare module 'koa' {
+  interface DefaultContext {
+    db: Database;
+    cache: Cache;
+    resourcer: Resourcer;
+    i18n: any;
 
-  [key: string]: any;
+    [key: string]: any;
+  }
 }
 
 interface ActionsOptions {
   resourceName?: string;
   resourceNames?: string[];
-}
-
-interface ListenOptions {
-  port?: number | undefined;
-  host?: string | undefined;
-  backlog?: number | undefined;
-  path?: string | undefined;
-  exclusive?: boolean | undefined;
-  readableAll?: boolean | undefined;
-  writableAll?: boolean | undefined;
-  /**
-   * @default false
-   */
-  ipv6Only?: boolean | undefined;
-  signal?: AbortSignal | undefined;
 }
 
 interface StartOptions {
@@ -175,11 +162,7 @@ export type MaintainingCommandStatus = {
   error?: Error;
 };
 
-export class Application<StateT = DefaultState, ContextT = DefaultContext> extends Koa implements AsyncEmitter {
-  /**
-   * @internal
-   */
-  declare middleware: any;
+export class Application extends EventEmitter implements AsyncEmitter {
   /**
    * @internal
    */
@@ -223,10 +206,12 @@ export class Application<StateT = DefaultState, ContextT = DefaultContext> exten
   private _maintainingStatusBeforeCommand: MaintainingCommandStatus | null;
   private _actionCommand: Command;
   private _noticeManager: NoticeManager;
+  private _koa = new Koa();
   static KEY_CORE_APP_PREFIX = 'KEY_CORE_APP_';
   private currentId = nanoid();
   public container: ContainerInstance;
   public modules: Record<string, any> = {};
+  private _middleware = new Toposort<Koa.Middleware>();
   public middlewareSourceMap: WeakMap<Function, string> = new WeakMap();
 
   // WebSocket 事件处理器集合
@@ -255,6 +240,13 @@ export class Application<StateT = DefaultState, ContextT = DefaultContext> exten
 
   get noticeManager() {
     return this._noticeManager;
+  }
+
+  /**
+   * @deprecated
+   */
+  get context() {
+    return this._koa.context;
   }
 
   protected _loaded: boolean;
@@ -444,13 +436,10 @@ export class Application<StateT = DefaultState, ContextT = DefaultContext> exten
     return packageJson.version;
   }
 
-  // @ts-ignore
-  use<NewStateT = {}, NewContextT = {}>(
-    middleware: Koa.Middleware<StateT & NewStateT, ContextT & NewContextT>,
-    options?: ToposortOptions,
-  ) {
+  use(middleware: Koa.Middleware, options?: ToposortOptions) {
     this.middlewareSourceMap.set(middleware, getCurrentStacks());
-    this.middleware.add(middleware, options);
+    this._middleware.add(middleware, options);
+    this._koa.middleware = this._middleware.nodes;
     return this;
   }
 
@@ -458,16 +447,7 @@ export class Application<StateT = DefaultState, ContextT = DefaultContext> exten
    * @internal
    */
   callback() {
-    const fn = compose(this.middleware.nodes);
-
-    if (!this.listenerCount('error')) this.on('error', this.onerror);
-
-    return (req: IncomingMessage, res: ServerResponse) => {
-      const ctx = this.createContext(req, res);
-
-      // @ts-ignore
-      return this.handleRequest(ctx, fn);
-    };
+    return this._koa.callback();
   }
 
   /**
@@ -1066,7 +1046,7 @@ export class Application<StateT = DefaultState, ContextT = DefaultContext> exten
 
     this.reInitEvents();
 
-    this.middleware = new Toposort<any>();
+    const middleware = new Toposort<Koa.Middleware>();
     this.plugins = new Map<string, Plugin>();
 
     if (this.db) {
@@ -1221,8 +1201,6 @@ export class Application<StateT = DefaultState, ContextT = DefaultContext> exten
 
     return this;
   }
-
-  [key: string]: any;
 }
 
 applyMixins(Application, [AsyncEmitter]);

--- a/packages/core/src/application.ts
+++ b/packages/core/src/application.ts
@@ -128,7 +128,8 @@ declare module 'koa' {
 }
 
 declare module 'koa' {
-  interface DefaultContext {
+  interface ExtendableContext {
+    tego: Application;
     db: Database;
     cache: Cache;
     resourcer: Resourcer;

--- a/packages/core/src/application.ts
+++ b/packages/core/src/application.ts
@@ -37,6 +37,7 @@ import lodash from 'lodash';
 import _ from 'lodash';
 import { nanoid } from 'nanoid';
 import semver from 'semver';
+import winston from 'winston';
 import WebSocket from 'ws';
 
 import packageJson from '../package.json';
@@ -135,6 +136,7 @@ declare module 'koa' {
     resourcer: Resourcer;
     i18n: any;
     reqId: string;
+    logger: winston.Logger;
 
     [key: string]: any;
   }
@@ -374,14 +376,6 @@ export class Application extends EventEmitter implements AsyncEmitter {
 
   get version() {
     return this._version;
-  }
-
-  /**
-   * Use {@link logger}
-   * @deprecated
-   */
-  get log() {
-    return this._logger;
   }
 
   get name() {

--- a/packages/core/src/helper.ts
+++ b/packages/core/src/helper.ts
@@ -39,6 +39,7 @@ export function registerMiddlewares(app: Application, options: ApplicationOption
   app.use(
     async (ctx, next) => {
       ctx.reqId = randomUUID();
+      ctx.tego = app;
       await next();
     },
     { tag: 'UUID' },
@@ -143,7 +144,7 @@ export const enablePerfHooks = (app: Application) => {
     actions: {
       view: async (ctx, next) => {
         const result = {};
-        const histograms = ctx.app.perfHistograms as Map<string, RecordableHistogram>;
+        const histograms = ctx.tego.perfHistograms as Map<string, RecordableHistogram>;
         const sortedHistograms = [...histograms.entries()].sort(([i, a], [j, b]) => b.mean - a.mean);
         sortedHistograms.forEach(([name, histogram]) => {
           result[name] = histogram;
@@ -152,7 +153,7 @@ export const enablePerfHooks = (app: Application) => {
         await next();
       },
       reset: async (ctx, next) => {
-        const histograms = ctx.app.perfHistograms as Map<string, RecordableHistogram>;
+        const histograms = ctx.tego.perfHistograms as Map<string, RecordableHistogram>;
         histograms.forEach((histogram: RecordableHistogram) => histogram.reset());
         await next();
       },

--- a/packages/core/src/helper.ts
+++ b/packages/core/src/helper.ts
@@ -38,7 +38,7 @@ export function createResourcer(options: ApplicationOptions) {
 export function registerMiddlewares(app: Application, options: ApplicationOptions) {
   app.use(
     async (ctx, next) => {
-      app.context.reqId = randomUUID();
+      ctx.reqId = randomUUID();
       await next();
     },
     { tag: 'UUID' },

--- a/packages/core/src/locale/locale.ts
+++ b/packages/core/src/locale/locale.ts
@@ -55,7 +55,6 @@ export class Locale {
       resources: await this.getCacheResources(lang),
     };
     for (const [name, fn] of this.localeFn) {
-      // this.app.log.debug(`load [${name}] locale resource `);
       const result = await this.wrapCache(`${name}:${lang}`, async () => {
         this.cache.del(`eTag:${lang}`);
         return await fn(lang);
@@ -114,8 +113,6 @@ export class Locale {
         if (!packageName) {
           continue;
         }
-        // this.app.log.debug(`load [${packageName}] locale resource `);
-        // this.app.setMaintainingMessage(`load [${packageName}] locale resource `);
         const res = getResource(packageName, lang);
         if (res) {
           resources[packageName] = { ...res };

--- a/packages/core/src/middlewares/db2resource.ts
+++ b/packages/core/src/middlewares/db2resource.ts
@@ -1,7 +1,7 @@
-import Database from '@tachybase/database';
-import { getNameByParams, parseRequest, ResourcerContext, ResourceType } from '@tachybase/resourcer';
+import { Context } from '@tachybase/actions';
+import { getNameByParams, parseRequest, ResourceType } from '@tachybase/resourcer';
 
-export async function db2resource(ctx: ResourcerContext & { db: Database }, next: () => Promise<any>) {
+export async function db2resource(ctx: Context, next: () => Promise<any>) {
   const dataSource = ctx.get('x-data-source');
   if (dataSource) {
     return next();

--- a/packages/core/src/middlewares/i18n.ts
+++ b/packages/core/src/middlewares/i18n.ts
@@ -5,13 +5,13 @@ export async function i18n(ctx, next) {
     const lng =
       ctx.get('X-Locale') ||
       (ctx.request.query.locale as string) ||
-      ctx.app.i18n.language ||
+      ctx.tego.i18n.language ||
       ctx.acceptsLanguages().shift() ||
       'en-US';
     return lng;
   };
   const lng = ctx.getCurrentLocale();
-  const localeManager = ctx.app.localeManager as Locale;
+  const localeManager = ctx.tego.localeManager as Locale;
   const i18n = await localeManager.getI18nInstance(lng);
   ctx.i18n = i18n;
   ctx.t = i18n.t.bind(i18n);

--- a/packages/core/src/middlewares/parse-variables.ts
+++ b/packages/core/src/middlewares/parse-variables.ts
@@ -1,6 +1,7 @@
+import { Context } from '@tachybase/actions';
 import { getDateVars, parseFilter } from '@tachybase/utils';
 
-function getUser(ctx) {
+function getUser(ctx: Context) {
   return async ({ fields }) => {
     const userFields = fields.filter((f) => f && ctx.db.getFieldByPath('users.' + f));
     ctx.logger?.info('filter-parse: ', { userFields });

--- a/packages/core/src/plugin-manager/options/resource.ts
+++ b/packages/core/src/plugin-manager/options/resource.ts
@@ -12,7 +12,7 @@ export default {
   name: 'pm',
   actions: {
     async add(ctx, next) {
-      const app = ctx.app as Application;
+      const app = ctx.tego as Application;
       const { values = {} } = ctx.action.params;
       if (values?.packageName) {
         const args = [];
@@ -47,7 +47,7 @@ export default {
       await next();
     },
     async update(ctx, next) {
-      const app = ctx.app as Application;
+      const app = ctx.tego as Application;
       const values = ctx.action.params.values || {};
       const args = [];
       if (values.registry) {
@@ -87,13 +87,13 @@ export default {
       if (!filterByTk) {
         ctx.throw(400, 'plugin name invalid');
       }
-      const pm = ctx.app.pm;
+      const pm = ctx.tego.pm;
       ctx.body = await pm.getNpmVersionList(filterByTk);
       await next();
     },
     async enable(ctx, next) {
       const { filterByTk } = ctx.action.params;
-      const app = ctx.app as Application;
+      const app = ctx.tego as Application;
       if (!filterByTk) {
         ctx.throw(400, 'plugin name invalid');
       }
@@ -106,7 +106,7 @@ export default {
       if (!filterByTk) {
         ctx.throw(400, 'plugin name invalid');
       }
-      const app = ctx.app as Application;
+      const app = ctx.tego as Application;
       app.runAsCLI(['pm', 'disable', filterByTk], { from: 'user' });
       ctx.body = filterByTk;
       await next();
@@ -116,15 +116,15 @@ export default {
       if (!filterByTk) {
         ctx.throw(400, 'plugin name invalid');
       }
-      const app = ctx.app as Application;
+      const app = ctx.tego as Application;
       app.runAsCLI(['pm', 'remove', filterByTk], { from: 'user' });
       ctx.body = filterByTk;
       await next();
     },
     async list(ctx, next) {
       const locale = ctx.getCurrentLocale();
-      const pm = ctx.app.pm as PluginManager;
-      if (ctx.app.name === 'main') {
+      const pm = ctx.tego.pm as PluginManager;
+      if (ctx.tego.name === 'main') {
         ctx.body = await pm.list({ locale, isPreset: false });
       } else {
         ctx.body = await pm.list({ locale, isPreset: false, subView: true });
@@ -159,7 +159,7 @@ export default {
     },
     async get(ctx, next) {
       const locale = ctx.getCurrentLocale();
-      const pm = ctx.app.pm as PluginManager;
+      const pm = ctx.tego.pm as PluginManager;
       const { filterByTk } = ctx.action.params;
       if (!filterByTk) {
         ctx.throw(400, 'plugin name invalid');

--- a/packages/logger/src/request-logger.ts
+++ b/packages/logger/src/request-logger.ts
@@ -30,7 +30,7 @@ export const requestLogger = (appName: string, options?: RequestLoggerOptions) =
     const reqId = ctx.reqId;
     const path = /^\/api\/(.+):(.+)/.exec(ctx.path);
     const contextLogger = ctx.tego.log.child({ reqId, module: path?.[1], submodule: path?.[2] });
-    ctx.logger = ctx.log = contextLogger;
+    ctx.logger = contextLogger;
     const startTime = Date.now();
     const requestInfo = {
       method: ctx.method,

--- a/packages/logger/src/request-logger.ts
+++ b/packages/logger/src/request-logger.ts
@@ -29,8 +29,7 @@ export const requestLogger = (appName: string, options?: RequestLoggerOptions) =
   return async (ctx, next) => {
     const reqId = ctx.reqId;
     const path = /^\/api\/(.+):(.+)/.exec(ctx.path);
-    const contextLogger = ctx.app.log.child({ reqId, module: path?.[1], submodule: path?.[2] });
-    // ctx.reqId = reqId;
+    const contextLogger = ctx.tego.log.child({ reqId, module: path?.[1], submodule: path?.[2] });
     ctx.logger = ctx.log = contextLogger;
     const startTime = Date.now();
     const requestInfo = {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -86,14 +86,7 @@ export {
   WSServer,
   AesEncryptor,
 } from '@tego/core';
-export type {
-  AppLoggerOptions,
-  DefaultContext,
-  DefaultState,
-  ApplicationOptions,
-  InstallOptions,
-  PluginOptions,
-} from '@tego/core';
+export type { AppLoggerOptions, ApplicationOptions, InstallOptions, PluginOptions } from '@tego/core';
 export { AuthError, AuthErrorCode, AuthManager, BaseAuth } from '@tachybase/auth';
 export type {
   AuthConfig,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,6 +101,9 @@ importers:
 
   packages/acl:
     dependencies:
+      '@tachybase/actions':
+        specifier: workspace:*
+        version: link:../actions
       '@tachybase/resourcer':
         specifier: workspace:*
         version: link:../resourcer
@@ -120,6 +123,9 @@ importers:
       '@types/lodash':
         specifier: 4.17.20
         version: 4.17.20
+      '@types/minimatch':
+        specifier: ^6.0.0
+        version: 6.0.0
       '@types/node':
         specifier: 20.17.10
         version: 20.17.10
@@ -1235,24 +1241,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@ast-grep/napi-linux-arm64-musl@0.37.0':
     resolution: {integrity: sha512-LF9sAvYy6es/OdyJDO3RwkX3I82Vkfsng1sqUBcoWC1jVb1wX5YVzHtpQox9JrEhGl+bNp7FYxB4Qba9OdA5GA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@ast-grep/napi-linux-x64-gnu@0.37.0':
     resolution: {integrity: sha512-TViz5/klqre6aSmJzswEIjApnGjJzstG/SE8VDWsrftMBMYt2PTu3MeluZVwzSqDao8doT/P+6U11dU05UOgxw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@ast-grep/napi-linux-x64-musl@0.37.0':
     resolution: {integrity: sha512-/BcCH33S9E3ovOAEoxYngUNXgb+JLg991sdyiNP2bSoYd30a9RHrG7CYwW6fMgua3ijQ474eV6cq9yZO1bCpXg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@ast-grep/napi-win32-arm64-msvc@0.37.0':
     resolution: {integrity: sha512-TjQA4cFoIEW2bgjLkaL9yqT4XWuuLa5MCNd0VCDhGRDMNQ9+rhwi9eLOWRaap3xzT7g+nlbcEHL3AkVCD2+b3A==}
@@ -2350,21 +2360,25 @@ packages:
     resolution: {integrity: sha512-lk3sn52txGRuZUvrJ5DuH1vzgFeesjDjDPXUXjzANx4OCFiWjf3WChdouhiP8RbaTi2UF53X5y5oceonP9smcQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/linux-arm64-musl@1.10.0':
     resolution: {integrity: sha512-5bwCfCYS3dbsxa3MQLzq2sFZ0vGXpQNiu7LAU7CkgbsVmUl2vXOgAB2Qm0/Dw2JIWz9ZF47oF06nod48PEUVFw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/linux-x64-gnu@1.10.0':
     resolution: {integrity: sha512-x8lWCTGqAsNWLO6OLJrpaeDZ27YV7fj7BPQm4967lh0BOVAeQFMHqGXP+lBTrWs9i1vzRfUmM7JaWOWd+TsiKw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/linux-x64-musl@1.10.0':
     resolution: {integrity: sha512-6u5uZMFL/yrA2rQsOxiWYoXiTYKLAVqaWYiXftPstUEfOGRJ1o1yDrN3AZ+40ucX9sntLGkc0Z9OrLHU/z1myA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/win32-arm64@1.10.0':
     resolution: {integrity: sha512-mQ+zWZflyF67NjYcxQ24ID0JFb9LoHoYAcfgIXyI7N8TwWdTllDVv/+0fYTah3rxuHsLY/iCbjKvvqf5FNMeoQ==}
@@ -2747,111 +2761,133 @@ packages:
     resolution: {integrity: sha512-+xmiDGGaSfIIOXMzkhJ++Oa0Gwvl9oXUeIiwarsdRXSe27HUIvjbSIpPxvnNsRebsNdUo7uAiQVgBD1hVriwSQ==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-gnueabihf@4.46.2':
     resolution: {integrity: sha512-EtP8aquZ0xQg0ETFcxUbU71MZlHaw9MChwrQzatiE8U/bvi5uv/oChExXC4mWhjiqK7azGJBqU0tt5H123SzVA==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.44.2':
     resolution: {integrity: sha512-bDHvhzOfORk3wt8yxIra8N4k/N0MnKInCW5OGZaeDYa/hMrdPaJzo7CSkjKZqX4JFUWjUGm88lI6QJLCM7lDrA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm-musleabihf@4.46.2':
     resolution: {integrity: sha512-qO7F7U3u1nfxYRPM8HqFtLd+raev2K137dsV08q/LRKRLEc7RsiDWihUnrINdsWQxPR9jqZ8DIIZ1zJJAm5PjQ==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.44.2':
     resolution: {integrity: sha512-NMsDEsDiYghTbeZWEGnNi4F0hSbGnsuOG+VnNvxkKg0IGDvFh7UVpM/14mnMwxRxUf9AdAVJgHPvKXf6FpMB7A==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-gnu@4.46.2':
     resolution: {integrity: sha512-3dRaqLfcOXYsfvw5xMrxAk9Lb1f395gkoBYzSFcc/scgRFptRXL9DOaDpMiehf9CO8ZDRJW2z45b6fpU5nwjng==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.44.2':
     resolution: {integrity: sha512-lb5bxXnxXglVq+7imxykIp5xMq+idehfl+wOgiiix0191av84OqbjUED+PRC5OA8eFJYj5xAGcpAZ0pF2MnW+A==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-musl@4.46.2':
     resolution: {integrity: sha512-fhHFTutA7SM+IrR6lIfiHskxmpmPTJUXpWIsBXpeEwNgZzZZSg/q4i6FU4J8qOGyJ0TR+wXBwx/L7Ho9z0+uDg==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.44.2':
     resolution: {integrity: sha512-Yl5Rdpf9pIc4GW1PmkUGHdMtbx0fBLE1//SxDmuf3X0dUC57+zMepow2LK0V21661cjXdTn8hO2tXDdAWAqE5g==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.46.2':
     resolution: {integrity: sha512-i7wfGFXu8x4+FRqPymzjD+Hyav8l95UIZ773j7J7zRYc3Xsxy2wIn4x+llpunexXe6laaO72iEjeeGyUFmjKeA==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.44.2':
     resolution: {integrity: sha512-03vUDH+w55s680YYryyr78jsO1RWU9ocRMaeV2vMniJJW/6HhoTBwyyiiTPVHNWLnhsnwcQ0oH3S9JSBEKuyqw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.46.2':
     resolution: {integrity: sha512-B/l0dFcHVUnqcGZWKcWBSV2PF01YUt0Rvlurci5P+neqY/yMKchGU8ullZvIv5e8Y1C6wOn+U03mrDylP5q9Yw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.44.2':
     resolution: {integrity: sha512-iYtAqBg5eEMG4dEfVlkqo05xMOk6y/JXIToRca2bAWuqjrJYJlx/I7+Z+4hSrsWU8GdJDFPL4ktV3dy4yBSrzg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.46.2':
     resolution: {integrity: sha512-32k4ENb5ygtkMwPMucAb8MtV8olkPT03oiTxJbgkJa7lJ7dZMr0GCFJlyvy+K8iq7F/iuOr41ZdUHaOiqyR3iQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.44.2':
     resolution: {integrity: sha512-e6vEbgaaqz2yEHqtkPXa28fFuBGmUJ0N2dOJK8YUfijejInt9gfCSA7YDdJ4nYlv67JfP3+PSWFX4IVw/xRIPg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-musl@4.46.2':
     resolution: {integrity: sha512-t5B2loThlFEauloaQkZg9gxV05BYeITLvLkWOkRXogP4qHXLkWSbSHKM9S6H1schf/0YGP/qNKtiISlxvfmmZw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.44.2':
     resolution: {integrity: sha512-evFOtkmVdY3udE+0QKrV5wBx7bKI0iHz5yEVx5WqDJkxp9YQefy4Mpx3RajIVcM6o7jxTvVd/qpC1IXUhGc1Mw==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-s390x-gnu@4.46.2':
     resolution: {integrity: sha512-YKjekwTEKgbB7n17gmODSmJVUIvj8CX7q5442/CK80L8nqOUbMtf8b01QkG3jOqyr1rotrAnW6B/qiHwfcuWQA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.44.2':
     resolution: {integrity: sha512-/bXb0bEsWMyEkIsUL2Yt5nFB5naLAwyOWMEviQfQY1x3l5WsLKgvZf66TM7UTfED6erckUVUJQ/jJ1FSpm3pRQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.46.2':
     resolution: {integrity: sha512-Jj5a9RUoe5ra+MEyERkDKLwTXVu6s3aACP51nkfnK9wJTraCC8IMe3snOfALkrjTYd2G1ViE1hICj0fZ7ALBPA==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.44.2':
     resolution: {integrity: sha512-3D3OB1vSSBXmkGEZR27uiMRNiwN08/RVAcBKwhUYPaiZ8bcvdeEwWPvbnXvvXHY+A/7xluzcN+kaiOFNiOZwWg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-x64-musl@4.46.2':
     resolution: {integrity: sha512-7kX69DIrBeD7yNp4A5b81izs8BqoZkCIaxQaOpumcJ1S/kmqNFjPhDu1LHeVXv0SexfHQv5cqHsxLOjETuqDuA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.44.2':
     resolution: {integrity: sha512-VfU0fsMK+rwdK8mwODqYeM2hDrF2WiHaSmCBrS7gColkQft95/8tphyzv2EupVxn3iE0FI78wzffoULH1G+dkw==}
@@ -2925,21 +2961,25 @@ packages:
     resolution: {integrity: sha512-ms6uwECUIcu+6e82C5HJhRMHnfsI+l33v7XQezntzRPN0+sG3EpikEoT7SGbgt4vDwaWLR7wS20suN4qd5r3GA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rspack/binding-linux-arm64-musl@1.4.11':
     resolution: {integrity: sha512-9evq0DOdxMN/H8VM8ZmyY9NSuBgILNVV6ydBfVPMHPx4r1E7JZGpWeKDegZcS5Erw3sS9kVSIxyX78L5PDzzKw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rspack/binding-linux-x64-gnu@1.4.11':
     resolution: {integrity: sha512-bHYFLxPPYBOSaHdQbEoCYGMQ1gOrEWj7Mro/DLfSHZi1a0okcQ2Q1y0i1DczReim3ZhLGNrK7k1IpFXCRbAobQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rspack/binding-linux-x64-musl@1.4.11':
     resolution: {integrity: sha512-wrm4E7q2k4+cwT6Uhp6hIQ3eUe/YoaUttj6j5TqHYZX6YeLrNPtD9+ne6lQQ17BV8wmm6NZsmoFIJ5xIptpRhQ==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rspack/binding-wasm32-wasi@1.4.11':
     resolution: {integrity: sha512-hiYxHZjaZ17wQtXyLCK0IdtOvMWreGVTiGsaHCxyeT+SldDG+r16bXNjmlqfZsjlfl1mkAqKz1dg+mMX28OTqw==}
@@ -3192,8 +3232,9 @@ packages:
   '@types/mime@3.0.4':
     resolution: {integrity: sha512-iJt33IQnVRkqeqC7PzBHPTC6fDlRNRW8vjrgqtScAhrmMwe8c4Eo7+fUGTa+XdWrpEgpyKWMYmi2dIwMAYRzPw==}
 
-  '@types/minimatch@5.1.2':
-    resolution: {integrity: sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==}
+  '@types/minimatch@6.0.0':
+    resolution: {integrity: sha512-zmPitbQ8+6zNutpwgcQuLcsEpn/Cj54Kbn7L5pX0Os5kdWplB7xPgEh/g+SWOB/qmows2gpuCaPyduq8ZZRnxA==}
+    deprecated: This is a stub types definition. minimatch provides its own type definitions, so you do not need this installed.
 
   '@types/ms@0.7.34':
     resolution: {integrity: sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==}
@@ -5143,24 +5184,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.26.0:
     resolution: {integrity: sha512-XxoEL++tTkyuvu+wq/QS8bwyTXZv2y5XYCMcWL45b8XwkiS8eEEEej9BkMGSRwxa5J4K+LDeIhLrS23CpQyfig==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.26.0:
     resolution: {integrity: sha512-1dkTfZQAYLj8MUSkd6L/+TWTG8V6Kfrzfa0T1fSlXCXQHrt1HC1/UepXHtKHDt/9yFwyoeayivxXAsApVxn6zA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.26.0:
     resolution: {integrity: sha512-yX3Rk9m00JGCUzuUhFEojY+jf/6zHs3XU8S8Vk+FRbnr4St7cjyMXdNjuA2LjiT8e7j8xHRCH8hyZ4H/btRE4A==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.26.0:
     resolution: {integrity: sha512-X/597/cFnCogy9VItj/+7Tgu5VLbAtDF7KZDPdSw0MaL6FL940th1y3HiOzFIlziVvAtbo0RB3NAae1Oofr+Tw==}
@@ -9840,7 +9885,7 @@ snapshots:
 
   '@types/glob@7.2.0':
     dependencies:
-      '@types/minimatch': 5.1.2
+      '@types/minimatch': 6.0.0
       '@types/node': 20.17.10
 
   '@types/http-assert@1.5.5': {}
@@ -9894,7 +9939,9 @@ snapshots:
 
   '@types/mime@3.0.4': {}
 
-  '@types/minimatch@5.1.2': {}
+  '@types/minimatch@6.0.0':
+    dependencies:
+      minimatch: 5.1.6
 
   '@types/ms@0.7.34': {}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App-level WebSocket event registration/removal and automatic WS event bridging.

* **Refactor**
  * Application now uses an internal HTTP server and ordered middleware pipeline; startup options streamlined and a deprecated context accessor retained for compatibility.

* **Chores**
  * Public type surface reduced and request context enhanced (per-request reqId and app reference exposed as "tego"); many internal references updated to use the new request app accessor.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->