### PR TITLE
fix(acl): allow explicit unbound strategy actions

### DIFF
--- a/packages/acl/src/__tests__/acl.test.ts
+++ b/packages/acl/src/__tests__/acl.test.ts
@@ -124,6 +124,30 @@ describe('acl', () => {
     expect(acl.can({ role: 'admin', resource: 'comments', action: 'create' })).toBeNull();
   });
 
+  it('should allow explicit unbound strategy actions outside configured strategy resources', () => {
+    acl.setAvailableAction('create', {
+      type: 'new-data',
+    });
+
+    acl.setAvailableStrategy('s1', {
+      displayName: 's1',
+      actions: ['create'],
+    });
+
+    acl.setStrategyResources(['posts']);
+
+    acl.define({
+      role: 'admin',
+      strategy: 's1',
+    });
+
+    expect(acl.can({ role: 'admin', resource: 'customPosts', action: 'create' })).toMatchObject({
+      role: 'admin',
+      resource: 'customPosts',
+      action: 'create',
+    });
+  });
+
   it('should clear strategy resource restrictions when set to null', () => {
     acl.setAvailableAction('create', {
       type: 'new-data',

--- a/packages/acl/src/acl-available-strategy.ts
+++ b/packages/acl/src/acl-available-strategy.ts
@@ -63,6 +63,10 @@ export class ACLAvailableStrategy {
     return false;
   }
 
+  isWildcard() {
+    return this.options.actions === '*';
+  }
+
   allow(resourceName: string, actionName: string) {
     return this.matchAction(this.acl.resolveActionAlias(actionName));
   }

--- a/packages/acl/src/acl.ts
+++ b/packages/acl/src/acl.ts
@@ -208,6 +208,21 @@ export class ACL extends EventEmitter {
     return this.availableActions;
   }
 
+  protected canUseStrategyForResource(resource: string, action: string, strategy: ACLAvailableStrategy | null) {
+    if (this.strategyResources === null || this.strategyResources.has(resource)) {
+      return true;
+    }
+
+    if (!strategy || strategy.isWildcard()) {
+      return false;
+    }
+
+    const availableAction = this.getAvailableAction(action);
+    const actionResource = availableAction?.options?.resource;
+
+    return !!availableAction && (!actionResource || actionResource === '*' || actionResource === resource);
+  }
+
   setAvailableStrategy(name: string, options: AvailableStrategyOptions) {
     this.availableStrategy.set(name, new ACLAvailableStrategy(this, options));
   }
@@ -272,9 +287,10 @@ export class ACL extends EventEmitter {
     }
 
     let roleStrategyParams;
+    const resolvedAction = this.resolveActionAlias(action);
 
-    if (this.strategyResources === null || this.strategyResources.has(resource)) {
-      roleStrategyParams = roleStrategy?.allow(resource, this.resolveActionAlias(action));
+    if (this.canUseStrategyForResource(resource, resolvedAction, roleStrategy)) {
+      roleStrategyParams = roleStrategy?.allow(resource, resolvedAction);
     }
 
     if (!roleStrategyParams && snippetAllowed) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ACL permission evaluation when resource restrictions are configured alongside action permissions. The system now properly determines whether a role's strategy applies to a given resource before granting permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->