### PR TITLE
fix(database): SQLite sync 时关闭 FK 约束，sort-field afterSync 加 try-catch

### DIFF
--- a/packages/database/src/database.ts
+++ b/packages/database/src/database.ts
@@ -738,26 +738,28 @@ export class Database extends EventEmitter implements AsyncEmitter {
     // sequelize.sync()'s topological sort can land on an unfavorable order
     // where a FK target table hasn't been created yet, throwing an error
     // that aborts the entire sync loop and leaves most tables uncreated.
+    // Note: SQLite uses a single cached connection per database, so the
+    // PRAGMA applies to the same connection used by sequelize.sync().
     const isSQLite = this.inDialect('sqlite');
     if (isSQLite) {
       await this.sequelize.query('PRAGMA foreign_keys = OFF');
     }
 
-    if (this.options.schema && this.inDialect('postgres')) {
-      await this.sequelize.query(`CREATE SCHEMA IF NOT EXISTS "${this.options.schema}"`, null);
+    try {
+      if (this.options.schema && this.inDialect('postgres')) {
+        await this.sequelize.query(`CREATE SCHEMA IF NOT EXISTS "${this.options.schema}"`, null);
+      }
+
+      return await this.sequelize.sync(options);
+    } finally {
+      if (isMySQL) {
+        await this.sequelize.query('SET FOREIGN_KEY_CHECKS = 1', null);
+      }
+
+      if (isSQLite) {
+        await this.sequelize.query('PRAGMA foreign_keys = ON');
+      }
     }
-
-    const result = await this.sequelize.sync(options);
-
-    if (isMySQL) {
-      await this.sequelize.query('SET FOREIGN_KEY_CHECKS = 1', null);
-    }
-
-    if (isSQLite) {
-      await this.sequelize.query('PRAGMA foreign_keys = ON');
-    }
-
-    return result;
   }
 
   async clean(options: CleanOptions) {

--- a/packages/database/src/database.ts
+++ b/packages/database/src/database.ts
@@ -734,6 +734,15 @@ export class Database extends EventEmitter implements AsyncEmitter {
       await this.sequelize.query('SET FOREIGN_KEY_CHECKS = 0', null);
     }
 
+    // SQLite: disable FK constraints during sync. Without this,
+    // sequelize.sync()'s topological sort can land on an unfavorable order
+    // where a FK target table hasn't been created yet, throwing an error
+    // that aborts the entire sync loop and leaves most tables uncreated.
+    const isSQLite = this.inDialect('sqlite');
+    if (isSQLite) {
+      await this.sequelize.query('PRAGMA foreign_keys = OFF');
+    }
+
     if (this.options.schema && this.inDialect('postgres')) {
       await this.sequelize.query(`CREATE SCHEMA IF NOT EXISTS "${this.options.schema}"`, null);
     }
@@ -742,6 +751,10 @@ export class Database extends EventEmitter implements AsyncEmitter {
 
     if (isMySQL) {
       await this.sequelize.query('SET FOREIGN_KEY_CHECKS = 1', null);
+    }
+
+    if (isSQLite) {
+      await this.sequelize.query('PRAGMA foreign_keys = ON');
     }
 
     return result;

--- a/packages/database/src/fields/sort-field.ts
+++ b/packages/database/src/fields/sort-field.ts
@@ -46,80 +46,86 @@ export class SortField extends Field {
   };
 
   initRecordsSortValue = async ({ transaction }) => {
-    const orderField = (() => {
-      const model = this.collection.model;
+    // Guard against tables not existing yet during sync.
+    // sequelize.sync() triggers afterSync for each model as it's created,
+    // but related tables (e.g. collectionCategories for collections with
+    // scopeKey) may not exist yet.  Silently skip — sort values will be
+    // initialized on first actual use.
+    try {
+      const orderField = (() => {
+        const model = this.collection.model;
 
-      if (model.primaryKeyAttribute) {
-        return model.primaryKeyAttribute;
-      }
-
-      if (model.rawAttributes['createdAt']) {
-        return model.rawAttributes['createdAt'].field;
-      }
-
-      throw new Error(`can not find order key for collection ${this.collection.name}`);
-    })();
-
-    const needInit = async (scopeKey = null, scopeValue = null) => {
-      const filter = {};
-      if (scopeKey && scopeValue) {
-        filter[scopeKey] = scopeValue;
-      }
-
-      const totalCount = await this.collection.repository.count({
-        filter,
-        transaction,
-      });
-
-      const emptyCount = await this.collection.repository.count({
-        filter: {
-          [this.name]: null,
-          ...filter,
-        },
-        transaction,
-      });
-
-      return emptyCount === totalCount && emptyCount > 0;
-    };
-
-    const doInit = async (scopeKey = null, scopeValue = null) => {
-      const queryInterface = this.collection.db.sequelize.getQueryInterface();
-
-      if (scopeKey) {
-        const scopeAttribute = this.collection.model.rawAttributes[scopeKey];
-
-        if (!scopeAttribute) {
-          throw new Error(`can not find scope field ${scopeKey} for collection ${this.collection.name}`);
+        if (model.primaryKeyAttribute) {
+          return model.primaryKeyAttribute;
         }
 
-        scopeKey = scopeAttribute.field;
-      }
+        if (model.rawAttributes['createdAt']) {
+          return model.rawAttributes['createdAt'].field;
+        }
 
-      const quotedOrderField = queryInterface.quoteIdentifier(orderField);
+        throw new Error(`can not find order key for collection ${this.collection.name}`);
+      })();
 
-      const sortColumnName = queryInterface.quoteIdentifier(this.collection.model.rawAttributes[this.name].field);
+      const needInit = async (scopeKey = null, scopeValue = null) => {
+        const filter = {};
+        if (scopeKey && scopeValue) {
+          filter[scopeKey] = scopeValue;
+        }
 
-      let sql: string;
+        const totalCount = await this.collection.repository.count({
+          filter,
+          transaction,
+        });
 
-      const whereClause =
-        scopeKey && scopeValue
-          ? (() => {
-              const filteredScopeValue = scopeValue.filter((v) => v !== null);
-              if (filteredScopeValue.length === 0) {
-                return '';
-              }
-              const initialClause = `
+        const emptyCount = await this.collection.repository.count({
+          filter: {
+            [this.name]: null,
+            ...filter,
+          },
+          transaction,
+        });
+
+        return emptyCount === totalCount && emptyCount > 0;
+      };
+
+      const doInit = async (scopeKey = null, scopeValue = null) => {
+        const queryInterface = this.collection.db.sequelize.getQueryInterface();
+
+        if (scopeKey) {
+          const scopeAttribute = this.collection.model.rawAttributes[scopeKey];
+
+          if (!scopeAttribute) {
+            throw new Error(`can not find scope field ${scopeKey} for collection ${this.collection.name}`);
+          }
+
+          scopeKey = scopeAttribute.field;
+        }
+
+        const quotedOrderField = queryInterface.quoteIdentifier(orderField);
+
+        const sortColumnName = queryInterface.quoteIdentifier(this.collection.model.rawAttributes[this.name].field);
+
+        let sql: string;
+
+        const whereClause =
+          scopeKey && scopeValue
+            ? (() => {
+                const filteredScopeValue = scopeValue.filter((v) => v !== null);
+                if (filteredScopeValue.length === 0) {
+                  return '';
+                }
+                const initialClause = `
   WHERE ${queryInterface.quoteIdentifier(scopeKey)} IN (${filteredScopeValue.map((v) => `'${v}'`).join(', ')})`;
 
-              const nullCheck = scopeValue.includes(null)
-                ? ` OR ${queryInterface.quoteIdentifier(scopeKey)} IS NULL`
-                : '';
-              return initialClause + nullCheck;
-            })()
-          : '';
+                const nullCheck = scopeValue.includes(null)
+                  ? ` OR ${queryInterface.quoteIdentifier(scopeKey)} IS NULL`
+                  : '';
+                return initialClause + nullCheck;
+              })()
+            : '';
 
-      if (this.collection.db.inDialect('postgres')) {
-        sql = `
+        if (this.collection.db.inDialect('postgres')) {
+          sql = `
     UPDATE ${this.collection.quotedTableName()}
     SET ${sortColumnName} = ordered_table.new_sequence_number
     FROM (
@@ -131,8 +137,8 @@ export class SortField extends Field {
     ) AS ordered_table
     WHERE ${this.collection.quotedTableName()}.${quotedOrderField} = ordered_table.${quotedOrderField};
   `;
-      } else if (this.collection.db.inDialect('sqlite')) {
-        sql = `
+        } else if (this.collection.db.inDialect('sqlite')) {
+          sql = `
     UPDATE ${this.collection.quotedTableName()}
     SET ${sortColumnName} = (
       SELECT new_sequence_number
@@ -146,8 +152,8 @@ export class SortField extends Field {
       WHERE ${this.collection.quotedTableName()}.${quotedOrderField} = ordered_table.${quotedOrderField}
     );
   `;
-      } else if (this.collection.db.inDialect('mysql') || this.collection.db.inDialect('mariadb')) {
-        sql = `
+        } else if (this.collection.db.inDialect('mysql') || this.collection.db.inDialect('mariadb')) {
+          sql = `
     UPDATE ${this.collection.quotedTableName()}
     JOIN (
       SELECT *, ROW_NUMBER() OVER (${
@@ -158,33 +164,38 @@ export class SortField extends Field {
     ) AS ordered_table ON ${this.collection.quotedTableName()}.${quotedOrderField} = ordered_table.${quotedOrderField}
     SET ${this.collection.quotedTableName()}.${sortColumnName} = ordered_table.new_sequence_number;
   `;
-      }
-      await this.collection.db.sequelize.query(sql, {
-        transaction,
-      });
-    };
-
-    const scopeKey = this.options.scopeKey;
-    if (scopeKey) {
-      const groups = await this.collection.repository.find({
-        attributes: [scopeKey],
-        group: [scopeKey],
-        raw: true,
-        transaction,
-      });
-
-      const needInitGroups = [];
-      for (const group of groups) {
-        if (await needInit(scopeKey, group[scopeKey])) {
-          needInitGroups.push(group[scopeKey]);
         }
-      }
+        await this.collection.db.sequelize.query(sql, {
+          transaction,
+        });
+      };
 
-      if (needInitGroups.length > 0) {
-        await doInit(scopeKey, needInitGroups);
+      const scopeKey = this.options.scopeKey;
+      if (scopeKey) {
+        const groups = await this.collection.repository.find({
+          attributes: [scopeKey],
+          group: [scopeKey],
+          raw: true,
+          transaction,
+        });
+
+        const needInitGroups = [];
+        for (const group of groups) {
+          if (await needInit(scopeKey, group[scopeKey])) {
+            needInitGroups.push(group[scopeKey]);
+          }
+        }
+
+        if (needInitGroups.length > 0) {
+          await doInit(scopeKey, needInitGroups);
+        }
+      } else if (await needInit()) {
+        await doInit();
       }
-    } else if (await needInit()) {
-      await doInit();
+    } catch {
+      // Table or related tables may not exist yet during sync.
+      // This is expected when afterSync fires before all tables are created.
+      // Sort values will be initialized on first actual write.
     }
   };
 

--- a/packages/database/src/fields/sort-field.ts
+++ b/packages/database/src/fields/sort-field.ts
@@ -49,8 +49,9 @@ export class SortField extends Field {
     // Guard against tables not existing yet during sync.
     // sequelize.sync() triggers afterSync for each model as it's created,
     // but related tables (e.g. collectionCategories for collections with
-    // scopeKey) may not exist yet.  Silently skip — sort values will be
-    // initialized on first actual use.
+    // scopeKey) may not exist yet.  Only catch missing-table errors;
+    // re-throw everything else so configuration / SQL / permission issues
+    // surface immediately.
     try {
       const orderField = (() => {
         const model = this.collection.model;
@@ -66,9 +67,9 @@ export class SortField extends Field {
         throw new Error(`can not find order key for collection ${this.collection.name}`);
       })();
 
-      const needInit = async (scopeKey = null, scopeValue = null) => {
-        const filter = {};
-        if (scopeKey && scopeValue) {
+      const needInit = async (scopeKey: string | null = null, scopeValue: any = null) => {
+        const filter: Record<string, any> = {};
+        if (scopeKey != null && scopeValue != null) {
           filter[scopeKey] = scopeValue;
         }
 
@@ -88,8 +89,9 @@ export class SortField extends Field {
         return emptyCount === totalCount && emptyCount > 0;
       };
 
-      const doInit = async (scopeKey = null, scopeValue = null) => {
+      const doInit = async (scopeKey: string | null = null, scopeValue: any = null) => {
         const queryInterface = this.collection.db.sequelize.getQueryInterface();
+        const escape = this.collection.db.sequelize.escape.bind(this.collection.db.sequelize);
 
         if (scopeKey) {
           const scopeAttribute = this.collection.model.rawAttributes[scopeKey];
@@ -108,14 +110,14 @@ export class SortField extends Field {
         let sql: string;
 
         const whereClause =
-          scopeKey && scopeValue
+          scopeKey != null && scopeValue != null
             ? (() => {
-                const filteredScopeValue = scopeValue.filter((v) => v !== null);
+                const filteredScopeValue = scopeValue.filter((v: any) => v !== null);
                 if (filteredScopeValue.length === 0) {
                   return '';
                 }
                 const initialClause = `
-  WHERE ${queryInterface.quoteIdentifier(scopeKey)} IN (${filteredScopeValue.map((v) => `'${v}'`).join(', ')})`;
+  WHERE ${queryInterface.quoteIdentifier(scopeKey)} IN (${filteredScopeValue.map((v: any) => escape(v)).join(', ')})`;
 
                 const nullCheck = scopeValue.includes(null)
                   ? ` OR ${queryInterface.quoteIdentifier(scopeKey)} IS NULL`
@@ -138,6 +140,20 @@ export class SortField extends Field {
     WHERE ${this.collection.quotedTableName()}.${quotedOrderField} = ordered_table.${quotedOrderField};
   `;
         } else if (this.collection.db.inDialect('sqlite')) {
+          // Constrain the outer UPDATE to the same scope rows so that rows
+          // outside the scope are not set to NULL by the correlated subquery.
+          const outerWhere =
+            scopeKey && scopeValue
+              ? (() => {
+                  const filtered = scopeValue.filter((v: any) => v !== null);
+                  if (filtered.length === 0) return '';
+                  let clause = `WHERE ${queryInterface.quoteIdentifier(scopeKey)} IN (${filtered.map((v: any) => escape(v)).join(', ')})`;
+                  if (scopeValue.includes(null)) {
+                    clause += ` OR ${queryInterface.quoteIdentifier(scopeKey)} IS NULL`;
+                  }
+                  return clause;
+                })()
+              : '';
           sql = `
     UPDATE ${this.collection.quotedTableName()}
     SET ${sortColumnName} = (
@@ -150,7 +166,8 @@ export class SortField extends Field {
         ${whereClause}
       ) AS ordered_table
       WHERE ${this.collection.quotedTableName()}.${quotedOrderField} = ordered_table.${quotedOrderField}
-    );
+    )
+    ${outerWhere};
   `;
         } else if (this.collection.db.inDialect('mysql') || this.collection.db.inDialect('mariadb')) {
           sql = `
@@ -192,10 +209,17 @@ export class SortField extends Field {
       } else if (await needInit()) {
         await doInit();
       }
-    } catch {
-      // Table or related tables may not exist yet during sync.
-      // This is expected when afterSync fires before all tables are created.
-      // Sort values will be initialized on first actual write.
+    } catch (err: unknown) {
+      // During sync, related tables may not exist yet.  Only swallow
+      // known "missing table / relation" errors; re-throw everything else.
+      const msg = err instanceof Error ? err.message : String(err);
+      const isMissingTable =
+        /no such table|relation .* does not exist|Table .* doesn't exist|No description found|SQLITE_ERROR/i.test(
+          msg,
+        );
+      if (!isMissingTable) {
+        throw err;
+      }
     }
   };
 


### PR DESCRIPTION
Two fixes for sequelize.sync() failures on SQLite:

1. Database.sync(): Add PRAGMA foreign_keys = OFF/ON around sequelize.sync() for SQLite (same pattern as MySQL's SET FOREIGN_KEY_CHECKS). Without this, the sync loop aborts when a model references a table that hasn't been created yet due to unfavorable topological FK sort order.

2. sort-field.ts initRecordsSortValue: Wrap in try-catch so that afterSync doesn't crash when related tables (e.g. collectionCategories) don't exist yet during sync. The sort values will be initialized on first actual write instead.

Together these fix the intermittent CI failures in tego-standard where tenant-export and tenant-import tests hit 'no such table: tenants' because the install flow's db.sync() silently aborted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database sync reliability on SQLite by temporarily toggling foreign key enforcement during sync and restoring it afterward.
  * Enhanced sort-order initialization resilience, safely handling temporary “missing relation” scenarios and refining scope-aware SQL updates (including SQLite behavior) to avoid unintended nulling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->