### PR TITLE
feat(test): enhance server test environment and vitest config factory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 *.sqlite
+*.tar.gz
 *.tbdump
+*.tgz
 .DS_Store
 .env
 .env.e2e

--- a/packages/test/setup/server.ts
+++ b/packages/test/setup/server.ts
@@ -1,6 +1,9 @@
 import path from 'node:path';
-import { setupServerTestEnvironment } from '@tachybase/test/server';
+import { patchCjsResolverForTestRuntime, setupServerTestEnvironment } from '@tachybase/test/server';
 import { initEnv } from '@tego/devkit';
+
+// Patch CJS resolver BEFORE any test modules load to prevent dual-instance bugs
+patchCjsResolverForTestRuntime();
 
 setupServerTestEnvironment({
   workspaceRoot: process.cwd(),

--- a/packages/test/src/server/setupTestEnvironment.ts
+++ b/packages/test/src/server/setupTestEnvironment.ts
@@ -1,5 +1,5 @@
 import fs from 'node:fs';
-import { createRequire } from 'node:module';
+import { createRequire, Module } from 'node:module';
 import os from 'node:os';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
@@ -26,6 +26,109 @@ const ImportedTachybaseGlobal = (TachybaseGlobalModule as any).getInstance
   ? TachybaseGlobalModule
   : (TachybaseGlobalModule as any).default;
 const testUnsafeBuiltinPlugins = new Set(['event-source', 'worker-thread']);
+const cjsResolverPatched = Symbol.for('tego.test.server-env-cjs-resolver-patched');
+
+function patchSlowBuffer() {
+  try {
+    const buffer = runtimeRequire('node:buffer');
+    buffer.SlowBuffer ??= buffer.Buffer;
+  } catch {
+    // ignore if buffer is not available
+  }
+}
+
+/**
+ * Patch CJS _resolveFilename so that @tego/server and @tego/core always resolve
+ * to the copy used by @tachybase/test. Call this at module level in your setup
+ * file (before setupServerTestEnvironment) to prevent dual-instance bugs.
+ */
+export function patchCjsResolverForTestRuntime(workspaceRoot?: string) {
+  if ((globalThis as any)[cjsResolverPatched]) {
+    return;
+  }
+
+  const resolvedWorkspaceRoot = workspaceRoot || process.cwd();
+  const workspaceRequire = createRequire(path.resolve(resolvedWorkspaceRoot, 'package.json'));
+  let testServerPath: string | undefined;
+  let testCorePath: string | undefined;
+  try {
+    testServerPath = selfRequire.resolve('@tego/server');
+  } catch {
+    // @tego/server not available through selfRequire
+  }
+  try {
+    testCorePath = selfRequire.resolve('@tego/core');
+  } catch {
+    // @tego/core not available through selfRequire
+  }
+
+  if (!testServerPath && !testCorePath) {
+    return;
+  }
+
+  const runtimeResolutions = new Map<string, string>();
+  if (testServerPath) {
+    runtimeResolutions.set('@tego/server', testServerPath);
+    try {
+      runtimeResolutions.set('@tego/server/package.json', selfRequire.resolve('@tego/server/package.json'));
+    } catch {
+      // ignore
+    }
+  }
+  if (testCorePath) {
+    runtimeResolutions.set('@tego/core', testCorePath);
+    try {
+      runtimeResolutions.set('@tego/core/package.json', selfRequire.resolve('@tego/core/package.json'));
+    } catch {
+      // ignore
+    }
+  }
+
+  const ModuleWithResolver = Module as typeof Module & {
+    _resolveFilename: (request: string, ...args: unknown[]) => string;
+  };
+  const originalResolveFilename = ModuleWithResolver._resolveFilename;
+  ModuleWithResolver._resolveFilename = function resolveTestRuntime(
+    this: unknown,
+    request: string,
+    ...args: unknown[]
+  ) {
+    return runtimeResolutions.get(request) || originalResolveFilename.call(this, request, ...args);
+  };
+
+  (globalThis as any)[cjsResolverPatched] = true;
+}
+
+function configureWorkerGlobalsForContexts(workspaceRoot: string, pluginPaths: string[]) {
+  const workspaceRequire = createRequire(path.resolve(workspaceRoot, 'package.json'));
+  const contexts = [runtimeRequire, selfRequire, workspaceRequire];
+
+  // Collect additional require contexts from @tego/core and @tego/server resolutions
+  for (const packageName of ['@tego/core', '@tego/server']) {
+    for (const req of [selfRequire, workspaceRequire]) {
+      try {
+        contexts.push(createRequire(req.resolve(`${packageName}/package.json`)));
+      } catch {
+        // ignore if package is not resolvable
+      }
+    }
+  }
+
+  const workerPaths = [workspaceRoot, ...pluginPaths];
+  const uniqueContexts = [...new Set(contexts)];
+  for (const req of uniqueContexts) {
+    try {
+      const tachybaseGlobal = getTachybaseGlobal(req);
+      tachybaseGlobal.getInstance().set('PLUGIN_PATHS', pluginPaths);
+      tachybaseGlobal.getInstance().set('WORKER_PATHS', workerPaths);
+      tachybaseGlobal.getInstance().set('WORKER_MODULES', []);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'MODULE_NOT_FOUND') {
+        throw error;
+      }
+    }
+  }
+}
 
 function createRuntimeRequire(workspaceRoot: string) {
   const hostPackageJson = path.resolve(workspaceRoot, 'package.json');
@@ -507,6 +610,14 @@ export function setupServerTestEnvironment(options: ServerTestEnvironmentOptions
   TachybaseGlobal.getInstance().set('WORKER_MODULES', []);
   process.env.TEGO_RUNTIME_HOME = path.join(os.tmpdir(), 'test-sqlite');
   process.env.APP_ENV_PATH = process.env.APP_ENV_PATH || '.env.test';
+
+  // Node 26 compatibility: jsonwebtoken@8 references SlowBuffer which no longer exists
+  patchSlowBuffer();
+
+  // Configure worker globals across all require contexts (workspace, self, core, server)
+  if (pluginPaths.length > 0) {
+    configureWorkerGlobalsForContexts(workspaceRoot, pluginPaths);
+  }
 
   const coreModules = getCoreModules(workspaceRoot, runtimeRequire);
   for (const core of coreModules) {

--- a/packages/test/src/vitest.ts
+++ b/packages/test/src/vitest.ts
@@ -63,15 +63,56 @@ function tsConfigPathsToAlias() {
 export interface TegoVitestConfigOptions {
   server?: {
     setupFile?: string;
+    /** Force CJS entry for @tachybase/test in server tests (avoids ESM createRequire issues). */
+    forceCjsEntry?: boolean;
   };
   client?: {
     setupFile?: string;
+    /** Override the default client test timeout (ms). */
+    testTimeout?: number;
   };
+  /** Additional path aliases merged with defaults from tsconfig.paths.json. */
+  aliases?: Array<{ find: string | RegExp; replacement: string }>;
 }
 
 export function defineTegoVitestConfig(options: TegoVitestConfigOptions = {}) {
   const serverSetupFile = options.server?.setupFile || resolve(packageRoot, './setup/server.ts');
   const clientSetupFiles = [resolve(packageRoot, './setup/client.ts'), options.client?.setupFile].filter(Boolean);
+  const mergedAliases = [...(options.aliases || []), ...tsConfigPathsToAlias()];
+
+  const serverProject: any = {
+    root: process.cwd(),
+    resolve: {
+      mainFields: ['module'],
+    },
+    extends: true,
+    test: {
+      name: 'server',
+      setupFiles: serverSetupFile,
+      include: ['packages/**/__tests__/**/*.test.ts', 'apps/**/__tests__/**/*.test.ts'],
+      exclude: [
+        '**/node_modules/**',
+        '**/dist/**',
+        '**/lib/**',
+        '**/es/**',
+        '**/e2e/**',
+        '**/__e2e__/**',
+        '**/{vitest,commitlint}.config.*',
+        'packages/**/{sdk,client,schema,components}/**/__tests__/**/*.{test,spec}.{ts,tsx}',
+      ],
+      alias: [...mergedAliases],
+    },
+  };
+
+  if (options.server?.forceCjsEntry) {
+    try {
+      const testRequire = createRequire(path.resolve(process.cwd(), 'node_modules/@tachybase/test/package.json'));
+      const testCjsEntry = testRequire.resolve('@tachybase/test');
+      serverProject.test.alias.push({ find: '@tachybase/test', replacement: testCjsEntry });
+    } catch {
+      // fallback: if @tachybase/test is not resolvable, skip forced CJS entry
+    }
+  }
 
   return defineConfig({
     test: {
@@ -90,30 +131,9 @@ export function defineTegoVitestConfig(options: TegoVitestConfigOptions = {}) {
       },
       silent: !!process.env.GITHUB_ACTIONS,
       globals: true,
-      alias: tsConfigPathsToAlias(),
+      alias: mergedAliases,
       projects: [
-        {
-          root: process.cwd(),
-          resolve: {
-            mainFields: ['module'],
-          },
-          extends: true,
-          test: {
-            name: 'server',
-            setupFiles: serverSetupFile,
-            include: ['packages/**/__tests__/**/*.test.ts', 'apps/**/__tests__/**/*.test.ts'],
-            exclude: [
-              '**/node_modules/**',
-              '**/dist/**',
-              '**/lib/**',
-              '**/es/**',
-              '**/e2e/**',
-              '**/__e2e__/**',
-              '**/{vitest,commitlint}.config.*',
-              'packages/**/{sdk,client,schema,components}/**/__tests__/**/*.{test,spec}.{ts,tsx}',
-            ],
-          },
-        },
+        serverProject,
         {
           // @ts-ignore
           plugins: [react()],
@@ -130,7 +150,8 @@ export function defineTegoVitestConfig(options: TegoVitestConfigOptions = {}) {
             setupFiles: clientSetupFiles,
             environment: 'jsdom',
             css: false,
-            alias: tsConfigPathsToAlias(),
+            alias: mergedAliases,
+            testTimeout: options.client?.testTimeout,
             include: ['packages/**/{sdk,client,schema,components}/**/__tests__/**/*.{test,spec}.{ts,tsx}'],
             exclude: [
               '**/node_modules/**',


### PR DESCRIPTION
- Add SlowBuffer patch for Node 26 compatibility in setupServerTestEnvironment
- Export patchCjsResolverForTestRuntime for workspace-level CJS resolver fixes
- Add multi-context worker globals configuration across all require contexts
- Enhance defineTegoVitestConfig with aliases, forceCjsEntry, and clientTestTimeout options
- Set project-level aliases to ensure proper inheritance in Vitest projects
- Update default setup/server.ts to use new capabilities
- Ignore pnpm pack tarball artifacts (*.tgz, *.tar.gz) in .gitignore

Enables downstream repos to use thin vitest configuration by moving general-purpose test infrastructure into the core package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test environment reliability to reduce issues caused by module resolution conflicts.
  * Added compatibility handling for newer Node versions in test runs.
  * Updated ignore rules to exclude additional archive files from version control.

* **New Features**
  * Expanded Vitest configuration options to support custom aliases, server entry behavior, and client test timeout settings.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->