### PR TITLE
feat: make request body limit configurable

### DIFF
--- a/packages/globals/src/settings.d.ts
+++ b/packages/globals/src/settings.d.ts
@@ -3,6 +3,7 @@ export interface Settings {
     APP_ENV: string;
     APP_PORT: number;
     APP_KEY: string;
+    APP_REQUEST_BODY_LIMIT?: string;
     INIT_APP_LANG: string;
     INIT_ROOT_EMAIL: string;
     INIT_ROOT_USERNAME: string;

--- a/packages/tego/presets/settings.js
+++ b/packages/tego/presets/settings.js
@@ -7,6 +7,7 @@ module.exports = {
     APP_ENV: 'development',
     APP_PORT: 3000,
     APP_KEY: 'test-key',
+    APP_REQUEST_BODY_LIMIT: '10mb',
     API_BASE_PATH: '/api/',
     INIT_APP_LANG: 'en-US',
     INIT_ROOT_EMAIL: 'admin@tachybase.com',

--- a/packages/tego/src/__tests__/config.test.ts
+++ b/packages/tego/src/__tests__/config.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import { getBodyParserOptions } from '../config';
+
+describe('getBodyParserOptions', () => {
+  it('uses APP_REQUEST_BODY_LIMIT for all parsed body types', () => {
+    const result = getBodyParserOptions({
+      APP_REQUEST_BODY_LIMIT: ' 50mb ',
+    });
+
+    expect(result).toEqual({
+      jsonLimit: '50mb',
+      formLimit: '50mb',
+      textLimit: '50mb',
+    });
+  });
+
+  it('uses the core default when APP_REQUEST_BODY_LIMIT is not set', () => {
+    expect(getBodyParserOptions({})).toEqual({
+      jsonLimit: '10mb',
+      formLimit: '10mb',
+      textLimit: '10mb',
+    });
+  });
+
+  it('rejects APP_REQUEST_BODY_LIMIT without a unit', () => {
+    expect(() =>
+      getBodyParserOptions({
+        APP_REQUEST_BODY_LIMIT: '10485760',
+      }),
+    ).toThrow('Invalid APP_REQUEST_BODY_LIMIT "10485760"');
+  });
+
+  it('rejects invalid APP_REQUEST_BODY_LIMIT values', () => {
+    expect(() =>
+      getBodyParserOptions({
+        APP_REQUEST_BODY_LIMIT: 'ten mb',
+      }),
+    ).toThrow('Expected a positive integer followed by b, kb, mb, gb, or tb.');
+  });
+});

--- a/packages/tego/src/config.ts
+++ b/packages/tego/src/config.ts
@@ -2,11 +2,31 @@ import { parseDatabaseOptionsFromEnv } from '@tachybase/database';
 import TachybaseGlobal from '@tachybase/globals';
 import { getLoggerLevel, getLoggerTransport } from '@tachybase/logger';
 
+const DEFAULT_REQUEST_BODY_LIMIT = '10mb';
+const SIZE_LIMIT_PATTERN = /^[1-9]\d*(?:b|kb|mb|gb|tb)$/i;
+
+export function getBodyParserOptions(env: NodeJS.ProcessEnv = process.env) {
+  const requestBodyLimit = env.APP_REQUEST_BODY_LIMIT?.trim() || DEFAULT_REQUEST_BODY_LIMIT;
+
+  if (!SIZE_LIMIT_PATTERN.test(requestBodyLimit)) {
+    throw new Error(
+      `Invalid APP_REQUEST_BODY_LIMIT "${requestBodyLimit}". Expected a positive integer followed by b, kb, mb, gb, or tb.`,
+    );
+  }
+
+  return {
+    jsonLimit: requestBodyLimit,
+    formLimit: requestBodyLimit,
+    textLimit: requestBodyLimit,
+  };
+}
+
 export async function getConfig() {
   return {
     database: {
       ...(await parseDatabaseOptionsFromEnv()),
     } as any,
+    bodyParser: getBodyParserOptions(),
     resourcer: {
       prefix: process.env.API_BASE_PATH || '/api/',
     },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an environment setting to control the maximum request body size limit.
  * The limit is applied consistently to JSON, form, and text parsing, with empty/unset values using the default.
  * Invalid values are now rejected to prevent misconfigured request parsing.
  * Exposed the new parsing configuration via the app’s generated config.
* **Tests**
  * Expanded coverage for trimming behavior, default fallback, and validation/error handling for invalid inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->